### PR TITLE
get larger twitter user avatars using a trick from Bridgy source 

### DIFF
--- a/twitter.py
+++ b/twitter.py
@@ -680,9 +680,14 @@ class Twitter(source.Source):
     else:
       url = self.user_url(username)
 
+    image = user.get('profile_image_url_https') or user.get('profile_image_url')
+    if image:
+      # remove _normal for a ~256x256 avatar rather than ~48x48
+      image = image.replace('_normal.', '.', 1)
+
     return util.trim_nulls({
       'displayName': user.get('name'),
-      'image': {'url': user.get('profile_image_url')},
+      'image': {'url': image},
       'id': self.tag_uri(username),
       # numeric_id is our own custom field that always has the source's numeric
       # user id, if available.

--- a/twitter_test.py
+++ b/twitter_test.py
@@ -27,7 +27,7 @@ USER = {  # Twitter
   'description': 'my description',
   'location': 'San Francisco',
   'name': 'Ryan Barrett',
-  'profile_image_url': 'http://a0.twimg.com/profile_images/866165047/ryan_normal.jpg',
+  'profile_image_url': 'http://a0.twimg.com/profile_images/866165047/ryan.jpg',
   'screen_name': 'snarfed_org',
   'id_str': '888',
   'protected': False,
@@ -39,7 +39,7 @@ USER = {  # Twitter
 ACTOR = {  # ActivityStreams
   'displayName': 'Ryan Barrett',
   'image': {
-    'url': 'http://a0.twimg.com/profile_images/866165047/ryan_normal.jpg',
+    'url': 'http://a0.twimg.com/profile_images/866165047/ryan.jpg',
     },
   'id': tag_uri('snarfed_org'),
   'numeric_id': '888',
@@ -456,7 +456,7 @@ ATOM = """\
 
 <subtitle>my description</subtitle>
 
-<logo>http://a0.twimg.com/profile_images/866165047/ryan_normal.jpg</logo>
+<logo>http://a0.twimg.com/profile_images/866165047/ryan.jpg</logo>
 <updated>2012-02-22T20:26:41</updated>
 <author>
  <activity:object-type>http://activitystrea.ms/schema/1.0/person</activity:object-type>
@@ -465,7 +465,7 @@ ATOM = """\
 </author>
 
 <link href="https://snarfed.org/" rel="alternate" type="text/html" />
-<link rel="avatar" href="http://a0.twimg.com/profile_images/866165047/ryan_normal.jpg" />
+<link rel="avatar" href="http://a0.twimg.com/profile_images/866165047/ryan.jpg" />
 <link href="%(request_url)s" rel="self" type="application/atom+xml" />
 <!-- TODO -->
 <!-- <link href="" rel="hub" /> -->


### PR DESCRIPTION
Hi Ryan, I'm sure you've considered this, but I was curious what you think about removing _normal from the Twitter user image URL in user_to_actor to get a larger profile image (I got the trick from Bridgy's twitter module)?

Feel 100% free to reject this PR, it won't hurt my feelings. I just figured it was friendlier than asking for a feature outright ;)
