### PR TITLE
added Source.can_create() to check for known unsupported types

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -360,6 +360,15 @@ class Facebook(source.Source):
         resp = json.loads(self.urlopen(API_FEED_URL, data=msg_data).read())
         resp.update({'url': self.post_url(resp), 'type': 'post'})
 
+    elif verb and verb == 'share':
+      # Facebook has shares, but the Facebook does not let us post them.
+      # Give a helpful error
+      raise source.CannotPublishTypeError(
+        'Cannot publish shares on Facebook.',
+        'Cannot publish <a href="http://indiewebcamp.com/repost">shares</a> '
+        'on Facebook. This limitation is imposed by the '
+        '<a href="https://developers.facebook.com/docs/graph-api/reference/v2.0/object/sharedposts/#publish">Facebook Graph API</a>.')
+
     else:
       raise NotImplementedError()
 

--- a/facebook_test.py
+++ b/facebook_test.py
@@ -1070,3 +1070,27 @@ class FacebookTest(testutil.HandlerTest):
     for fn in self.facebook.create, self.facebook.preview_create:
       self.assertRaises(NotImplementedError, fn,
                         {'objectType': 'activity', 'verb': 'share'})
+
+  def test_can_create_simple(self):
+    """Make can_create returns True for a simple message
+    """
+    can, err_plain, err_html = self.facebook.can_create({
+      'objectType': 'note',
+      'content': 'Lorem ipsum dolor sit amet'
+    })
+    self.assertTrue(can)
+    self.assertIsNone(err_plain)
+    self.assertIsNone(err_html)
+
+  def test_cannot_create_share(self):
+    """Make can_create returns False for shares on Facebook
+    """
+    can, err_plain, err_html = self.facebook.can_create({
+      'objectType': 'activity',
+      'verb': 'share',
+      'object': [{'url': 'http://facebook.com/johndoe/posts/12345'}],
+      'content': 'Sharing this',
+    })
+    self.assertFalse(can)
+    self.assertIn('Cannot publish shares', err_plain)
+    self.assertIn('Cannot publish', err_html)

--- a/twitter.py
+++ b/twitter.py
@@ -474,6 +474,13 @@ class Twitter(source.Source):
         resp = json.loads(self.urlopen(API_POST_TWEET_URL, data=data).read())
         resp['type'] = 'post'
 
+    elif verb and verb.startswith('rsvp-'):
+      # Twitter cannot publish event rsvps. Give a helpful error message if
+      # the user tries to.
+      raise source.CannotPublishTypeError(
+        'Cannot publish RSVPs to Twitter.',
+        'Cannot publish <a href="http://indiewebcamp.com/rsvp">RSVPs</a> to Twitter.')
+
     else:
       raise NotImplementedError()
 

--- a/twitter_test.py
+++ b/twitter_test.py
@@ -1021,3 +1021,26 @@ class TwitterTest(testutil.HandlerTest):
     for fn in self.twitter.create, self.twitter.preview_create:
       self.assertRaises(NotImplementedError, fn,
                         {'objectType': 'activity', 'verb': 'rsvp-yes'})
+
+  def test_can_create_simple(self):
+    """Make can_create returns true for a simple message
+    """
+    can, err_plain, err_html = self.twitter.can_create({
+      'objectType': 'note',
+      'content': 'Lorem ipsum dolor sit amet'
+    })
+    self.assertTrue(can)
+    self.assertIsNone(err_plain)
+    self.assertIsNone(err_html)
+
+  def test_cannot_create_rsvp(self):
+    """Make can_create returns False for an RSVP
+    """
+    can, err_plain, err_html = self.twitter.can_create({
+      'objectType': 'activity',
+      'verb': 'rsvp-yes',
+      'content': "I'll be there!",
+    })
+    self.assertFalse(can)
+    self.assertIn('Cannot publish RSVPs', err_plain)
+    self.assertIn('Cannot publish', err_html)


### PR DESCRIPTION
- allows us to give intelligent errors when the user tries to publish
  something to a silo that just doesn't support it (e.g. Twitter and RSVPs)
- Source.preview_create() should raise the new type
  CannotPublishTypeError to indicate a known unpublishable type
