### PR TITLE
publish: improve error reporting for comments, likes, and shares

### DIFF
--- a/facebook_test.py
+++ b/facebook_test.py
@@ -962,14 +962,12 @@ class FacebookTest(testutil.HandlerTest):
         'content': 'my msg',
         })
     self.assert_equals(
-      ({'id': '123_456', 'url': 'https://facebook.com/123_456', 'type': 'post'},
-       None),
-      self.facebook.create(obj))
+      {'id': '123_456', 'url': 'https://facebook.com/123_456', 'type': 'post'},
+      self.facebook.create(obj).content)
 
-    preview, failure = self.facebook.preview_create(obj)
-    self.assertFalse(failure)
-    self.assertIn('will <span class="verb">post</span>', preview)
-    self.assertIn('<em>my msg</em>', preview)
+    preview = self.facebook.preview_create(obj)
+    self.assertIn('will <span class="verb">post</span>', preview.content)
+    self.assertIn('<em>my msg</em>', preview.content)
 
   def test_create_post_include_link(self):
     self.expect_urlopen(
@@ -984,9 +982,8 @@ class FacebookTest(testutil.HandlerTest):
         'url': 'http://obj',
         })
     self.facebook.create(obj, include_link=True)
-    preview, failure = self.facebook.preview_create(obj, include_link=True)
-    self.assertFalse(failure)
-    self.assertIn('my msg', preview)
+    preview = self.facebook.preview_create(obj, include_link=True)
+    self.assertIn('my msg', preview.content)
 
   def test_create_comment(self):
     self.expect_urlopen(
@@ -997,16 +994,15 @@ class FacebookTest(testutil.HandlerTest):
 
     obj = copy.deepcopy(COMMENT_OBJS[0])
     obj['summary'] = 'my cmt'
-    self.assert_equals(({
+    self.assert_equals({
       'id': '456_789',
       'url': 'https://facebook.com/547822715231468?comment_id=456_789',
       'type': 'comment'
-    }, None), self.facebook.create(obj))
+    }, self.facebook.create(obj).content)
 
-    preview, failure = self.facebook.preview_create(obj)
-    self.assertFalse(failure)
-    self.assertIn('<span class="verb">comment</span> <em>my cmt</em> on <a href="https://facebook.com/547822715231468">this post</a>', preview)
-    self.assertIn('<div class="fb-post" data-href="https://facebook.com/547822715231468">', preview)
+    preview = self.facebook.preview_create(obj)
+    self.assertIn('<span class="verb">comment</span> <em>my cmt</em> on <a href="https://facebook.com/547822715231468">this post</a>', preview.content)
+    self.assertIn('<div class="fb-post" data-href="https://facebook.com/547822715231468">', preview.content)
 
   def test_create_comment_other_domain(self):
     self.mox.ReplayAll()
@@ -1015,10 +1011,9 @@ class FacebookTest(testutil.HandlerTest):
     obj.update({'summary': 'my cmt', 'inReplyTo': [{'url': 'http://other'}]})
 
     for fn in (self.facebook.preview_create, self.facebook.create):
-      result, failure = fn(obj)
-      self.assertTrue(failure)
-      self.assertTrue(failure.abort)
-      self.assertIn('Could not', failure.plain)
+      result = fn(obj)
+      self.assertTrue(result.abort)
+      self.assertIn('Could not', result.error_plain)
 
   def test_create_comment_on_post_urls(self):
     urls = ('https://www.facebook.com/snarfed.org/posts/333',
@@ -1038,24 +1033,23 @@ class FacebookTest(testutil.HandlerTest):
           'inReplyTo': [{'url': url}],
           'content': 'my cmt',
           })
-      self.assert_equals(({
+      self.assert_equals({
         'id': '456_789',
         'url': 'https://facebook.com/333?comment_id=456_789',
         'type': 'comment',
-      }, None), self.facebook.create(obj))
+      }, self.facebook.create(obj).content)
 
   def test_create_like(self):
     self.expect_urlopen('https://graph.facebook.com/10100176064482163/likes',
                         'true', data='')
     self.mox.ReplayAll()
-    self.assert_equals(({'url': 'https://facebook.com/212038/posts/10100176064482163',
-                         'type': 'like'}, None),
-                       self.facebook.create(LIKE_OBJS[0]))
+    self.assert_equals({'url': 'https://facebook.com/212038/posts/10100176064482163',
+                        'type': 'like'},
+                       self.facebook.create(LIKE_OBJS[0]).content)
 
-    preview, failure = self.facebook.preview_create(LIKE_OBJS[0])
-    self.assertFalse(failure)
-    self.assertIn('<span class="verb">like</span> <a href="https://facebook.com/212038/posts/10100176064482163">this post</a>', preview)
-    self.assertIn('<div class="fb-post" data-href="https://facebook.com/212038/posts/10100176064482163">', preview)
+    preview = self.facebook.preview_create(LIKE_OBJS[0])
+    self.assertIn('<span class="verb">like</span> <a href="https://facebook.com/212038/posts/10100176064482163">this post</a>', preview.content)
+    self.assertIn('<div class="fb-post" data-href="https://facebook.com/212038/posts/10100176064482163">', preview.content)
 
   def test_create_rsvp(self):
     for endpoint in 'attending', 'declined', 'maybe':#, 'invited/567':
@@ -1066,47 +1060,44 @@ class FacebookTest(testutil.HandlerTest):
     for rsvp in RSVP_OBJS_WITH_ID[:3]:
       rsvp = copy.deepcopy(rsvp)
       rsvp['inReplyTo'] = [{'url': 'https://facebook.com/234/'}]
-      self.assert_equals(({'url': 'https://facebook.com/234/', 'type': 'rsvp'},
-                          None),
-                         self.facebook.create(rsvp))
+      self.assert_equals({'url': 'https://facebook.com/234/', 'type': 'rsvp'},
+                         self.facebook.create(rsvp).content)
 
-    preview, failure = self.facebook.preview_create(rsvp)
-    self.assertFalse(failure)
-    self.assertIn('<span class="verb">RSVP maybe</span>', preview)
-    self.assertIn('https://facebook.com/234/', preview)
+    preview = self.facebook.preview_create(rsvp)
+    self.assertIn('<span class="verb">RSVP maybe</span>', preview.content)
+    self.assertIn('https://facebook.com/234/', preview.content)
 
   def test_create_unsupported_type(self):
     for fn in self.facebook.create, self.facebook.preview_create:
-      result, failure = fn({'objectType': 'activity', 'verb': 'share'})
-      self.assertTrue(failure)
-      self.assertTrue(failure.abort)
-      self.assertIn('Cannot publish shares', failure.plain)
-      self.assertIn('Cannot publish', failure.html)
+      result = fn({'objectType': 'activity', 'verb': 'share'})
+      self.assertTrue(result.abort)
+      self.assertIn('Cannot publish shares', result.error_plain)
+      self.assertIn('Cannot publish', result.error_html)
 
   def test_create_rsvp_without_in_reply_to(self):
     for rsvp in RSVP_OBJS_WITH_ID[:3]:
       rsvp = copy.deepcopy(rsvp)
       rsvp['inReplyTo'] = [{'url': 'https://foo.com/1234'}]
-      result, failure = self.facebook.create(rsvp)
-      self.assertTrue(failure)
-      self.assertIn('missing an in-reply-to', failure.plain)
+      result = self.facebook.create(rsvp)
+      self.assertTrue(result.abort)
+      self.assertIn('missing an in-reply-to', result.error_plain)
 
   def test_create_comment_without_in_reply_to(self):
     obj = copy.deepcopy(COMMENT_OBJS[0])
     obj['inReplyTo'] = [{'url': 'http://foo.com/bar'}]
 
     for fn in (self.facebook.preview_create, self.facebook.create):
-      preview, failure = fn(obj)
-      self.assertTrue(failure)
-      self.assertIn('Could not find a Facebook status to reply to', failure.plain)
-      self.assertIn('Could not find a Facebook status to', failure.html)
+      preview = fn(obj)
+      self.assertTrue(preview.abort)
+      self.assertIn('Could not find a Facebook status to reply to', preview.error_plain)
+      self.assertIn('Could not find a Facebook status to', preview.error_html)
 
   def test_create_like_without_object(self):
     obj = copy.deepcopy(LIKE_OBJS[0])
     del obj['object']
 
     for fn in (self.facebook.preview_create, self.facebook.create):
-      preview, failure = fn(obj)
-      self.assertTrue(failure)
-      self.assertIn('Could not find a Facebook status to like', failure.plain)
-      self.assertIn('Could not find a Facebook status to', failure.html)
+      preview = fn(obj)
+      self.assertTrue(preview.abort)
+      self.assertIn('Could not find a Facebook status to like', preview.error_plain)
+      self.assertIn('Could not find a Facebook status to', preview.error_html)

--- a/source.py
+++ b/source.py
@@ -40,13 +40,30 @@ RSVP_CONTENTS = {
   'invite': 'is invited.',
   }
 
-# Provides a detailed description of publishing failures. If abort is
-# False, we should continue looking for an entry to publish; if True,
-# we should and immediately inform the user. plain text is sent in
-# response to failed publish webmentions; html will be displayed to
-# the user when publishing interactively.
-CreationFailure = collections.namedtuple('CreationFailure',
-                                         ['abort', 'plain', 'html'])
+CreationResult = collections.namedtuple('CreationResult', [
+  'content', 'abort', 'error_plain', 'error_html'])
+
+
+def creation_result(content=None, abort=False, error_plain=None,
+                    error_html=None):
+  """Create a new CreationResult named tuple, which the result of
+  create() and preview_create() to provides a detailed description of
+  publishing failures. If abort is False, we should continue looking
+  for an entry to publish; if True, we should immediately inform the
+  user. error_plain text is sent in response to failed publish
+  webmentions; error_html will be displayed to the user when
+  publishing interactively.
+
+  Args:
+    content: a unicode string for preview_create() or a dict for create()
+    abort: a boolean
+    error_plain: a string
+    error_html: a string
+
+  Return:
+    a CreationResult named tuple
+  """
+  return CreationResult(content, abort, error_plain, error_html)
 
 
 class Source(object):
@@ -175,14 +192,11 @@ class Source(object):
         (if it has one) in the content.
 
     Returns:
-      (a result dict, a CreationFailure object) a tuple
+      a CreationResult, whose contents will be a dict
 
-      The result dict may be None or empty. If the newly created
+      The dict may be None or empty. If the newly created
       object has an id or permalink, they'll be provided in the values
       for 'id' and 'url'.
-
-      CreationFailure will be non-None if the site doesn't support the
-      object type.
     """
     raise NotImplementedError()
 
@@ -202,10 +216,8 @@ class Source(object):
         (if it has one) in the content.
 
     Returns:
-      (unicode string HTML snippet, a CreationFailure object) a tuple
-
-      CreationFailure will be non-None if the site doesn't support the
-      object type.
+      a CreationResult, whose contents will be a unicode string
+      HTML snippet (or None)
     """
     raise NotImplementedError()
 


### PR DESCRIPTION
- change create methods to return a tuple containing the result and
  a descriptive "failure" object (instead of throwing
  NotImplementedError)
- give informative error messages when publishing comments, likes,
  or shares without a target url for the given silo
- added unit tests for the more detailed error reporting for facebook
  and twitter publishing

ref issue snarfed/bridgy#223
