### PR TITLE
Mf2 more robust parsing for activities

### DIFF
--- a/activitystreams.py
+++ b/activitystreams.py
@@ -157,8 +157,7 @@ class Handler(webapp2.RequestHandler):
       self.response.out.write(microformats2.activities_to_html(activities))
     elif format == 'json-mf2':
       self.response.headers['Content-Type'] = 'application/json'
-      items = [microformats2.object_to_json(a['object'], a.get('context', {}))
-               for a in activities]
+      items = [microformats2.object_to_json(a) for a in activities]
       self.response.out.write(json.dumps({'items': items}, indent=2))
 
     if 'plaintext' in self.request.params:

--- a/granary/atom.py
+++ b/granary/atom.py
@@ -48,7 +48,22 @@ def activities_to_atom(activities, actor, title=None, request_url=None,
     obj = a.get('object', {})
     # Render content as HTML; escape &s
     content = obj.get('content')
-    obj['rendered_content'] = _encode_ampersands(microformats2.render_content(obj))
+    rendered = []
+
+    for target_type, participle in ('share', 'Shared'), ('like', 'Liked'):
+      if source.object_type(a) == target_type:
+        if 'author' in obj and 'url' in obj:
+          rendered.append(
+            '<p>%s <a href="%s">a post</a> by <a href="%s">%s</a></p>' % (
+              participle, obj.get('url'), obj.get('author', {}).get('url'),
+              obj.get('author', {}).get('displayName')))
+        else:
+          rendered.append(
+            '<p>%s <a href="%s">a post</a>' % (
+              participle, obj.get('url', '#')))
+
+    rendered.append(microformats2.render_content(obj))
+    obj['rendered_content'] = _encode_ampersands('\n'.join(rendered))
 
     # Make sure every activity has the title field, since Atom <entry> requires
     # the title element.

--- a/granary/microformats2.py
+++ b/granary/microformats2.py
@@ -465,6 +465,8 @@ def hcard_to_html(hcard, parent_prop=None):
 
   Args:
     hcard: dict, decoded JSON h-card
+    parent_prop: string (optional), the property of the parent object where
+      this object is embedded, e.g. 'p-author'
 
   Returns: string, rendered HTML
   """
@@ -477,7 +479,7 @@ def hcard_to_html(hcard, parent_prop=None):
   photo = prop.get('photo')
   return HCARD.substitute(
     prop,
-    types=' '.join(hcard['type']),
+    types=' '.join(([parent_prop] if parent_prop else []) + hcard['type']),
     photo=img(photo, 'u-photo', '') if photo else '',
     linked_name=maybe_linked_name(hcard['properties']))
 

--- a/granary/microformats2.py
+++ b/granary/microformats2.py
@@ -85,110 +85,107 @@ def get_text(val):
   return val.get('value') if isinstance(val, dict) else val
 
 
-def object_to_json(act, trim_nulls=True):
+def object_to_json(obj, trim_nulls=True, entry_class='h-entry', default_object_type=None):
   """Converts an ActivityStreams activity to microformats2 JSON.
 
   Args:
-    act: dict, a decoded JSON ActivityStreams object
+    obj: dict, a decoded JSON ActivityStreams object
     trim_nulls: boolean, whether to remove elements with null or empty values
 
   Returns: dict, decoded microformats2 JSON
   """
-  if not act:
+  if not obj:
     return {}
 
-  types_map = {'article': ['h-entry', 'h-as-article'],
-               'comment': ['h-entry', 'p-comment'],
-               'like': ['h-entry', 'h-as-like'],
-               'note': ['h-entry', 'h-as-note'],
+  types_map = {'article': [entry_class, 'h-as-article'],
+               'comment': [entry_class, 'h-as-comment'],
+               'like': [entry_class, 'h-as-like'],
+               'note': [entry_class, 'h-as-note'],
                'person': ['h-card'],
-               'place': ['h-card', 'p-location'],
-               'share': ['h-entry', 'h-as-repost'],
-               'rsvp-yes': ['h-entry', 'h-as-rsvp'],
-               'rsvp-no': ['h-entry', 'h-as-rsvp'],
-               'rsvp-maybe': ['h-entry', 'h-as-rsvp'],
-               'invite': ['h-entry'],
+               'place': ['h-card', 'h-as-location'],
+               'share': [entry_class, 'h-as-repost'],  # should be h-as-share?
+               'rsvp-yes': [entry_class, 'h-as-rsvp'],
+               'rsvp-no': [entry_class, 'h-as-rsvp'],
+               'rsvp-maybe': [entry_class, 'h-as-rsvp'],
+               'invite': [entry_class],
                }
-  act_type = source.object_type(act)
+  obj_type = source.object_type(obj) or default_object_type
   # if the activity type is a post, then it's really just a conduit
-  # for the object.  for other verbs, the activity itself is the
+  # for the object. for other verbs, the activity itself is the
   # interesting thing
-  if act_type == 'post':
-    obj = act.get('object', {})
-    act_type = source.object_type(obj)
-    primary = obj
+  if obj_type == 'post':
+    primary = obj.get('object', {})
+    obj_type = source.object_type(primary) or default_object_type
   else:
-    primary = act
+    primary = obj
 
-  types = types_map.get(act_type, ['h-entry'])
+  types = types_map.get(obj_type, [entry_class])
 
-  url = act.get('url', '')
+  url = obj.get('url', primary.get('url', ''))
   content = primary.get('content', '')
   # TODO: extract snippet
   name = primary.get('displayName', primary.get('title'))
   summary = primary.get('summary')
 
-  author = act.get('author', act.get('actor', {}))
-  author = object_to_json(author, trim_nulls=False)
-  if author:
-    author['type'] = ['h-card']
+  author = obj.get('author', obj.get('actor', {}))
+  author = object_to_json(author, trim_nulls=False, default_object_type='person')
 
-  location = object_to_json(primary.get('location', {}), trim_nulls=False)
-  if location:
-    # FIXME p-location is not a valid type, maybe h-as-location?
-    location['type'] = ['h-card', 'p-location']
-
-  in_reply_tos = act.get('inReplyTo', []) + act.get('context', {}).get('inReplyTo', [])
-  if 'h-as-rsvp' in types and 'object' in act:
-    in_reply_tos.append(act['object'])
+  in_reply_tos = obj.get('inReplyTo', []) + obj.get('context', {}).get('inReplyTo', [])
+  if 'h-as-rsvp' in types and 'object' in obj:
+    in_reply_tos.append(obj['object'])
   # TODO: more tags. most will be p-category?
   ret = {
     'type': types,
     'properties': {
-      'uid': [act.get('id', '')],
+      'uid': [obj.get('id', '')],
       'name': [name],
       'summary': [summary],
-      'url': [url] + act.get('upstreamDuplicates', []),
-      'photo': [act.get('image', {}).get('url', '')],
-      'video': [act.get('stream', {}).get('url')],
-      'published': [act.get('published', '')],
-      'updated': [act.get('updated', '')],
+      'url': [url] + obj.get('upstreamDuplicates', []),
+      'photo': [obj.get('image', primary.get('image', {})).get('url', '')],
+      'video': [obj.get('stream', primary.get('stream', {})).get('url')],
+      'published': [obj.get('published', primary.get('published', ''))],
+      'updated': [obj.get('updated', primary.get('updated', ''))],
       'content': [{
           'value': xml.sax.saxutils.unescape(content),
-          'html': render_content(act, include_location=False),
-          }],
+          'html': render_content(primary, include_location=False),
+      }],
       'in-reply-to': util.trim_nulls([o.get('url') for o in in_reply_tos]),
       'author': [author],
-      'location': [location],
-      'comment': [object_to_json(c, trim_nulls=False)
-                  for c in act.get('replies', {}).get('items', [])],
+      'location': [object_to_json(
+        primary.get('location', {}), trim_nulls=False,
+        default_object_type='place')],
+      'comment': [object_to_json(c, trim_nulls=False, entry_class='h-cite')
+                  for c in obj.get('replies', {}).get('items', [])],
       }
     }
 
   # rsvp
   if 'h-as-rsvp' in types:
-    ret['properties']['rsvp'] = [act_type[len('rsvp-'):]]
-  elif act_type == 'invite':
-    invitee = object_to_json(act.get('object'), trim_nulls=False)
-    invitee['type'].append('p-invitee')
+    ret['properties']['rsvp'] = [obj_type[len('rsvp-'):]]
+  elif obj_type == 'invite':
+    invitee = object_to_json(obj.get('object'), trim_nulls=False,
+                             default_object_type='person')
     ret['properties']['invitee'] = [invitee]
-  # likes and reposts
-  # http://indiewebcamp.com/like#Counterproposal
+
+  # like and repost mentions
   for type, prop in ('like', 'like'), ('share', 'repost'):
-    if act_type == type:
+    if obj_type == type:
       # The ActivityStreams spec says the object property should always be a
       # single object, but it's useful to let it be a list, e.g. when a like has
       # multiple targets, e.g. a like of a post with original post URLs in it,
       # which brid.gy does.
-      objs = act.get('object', [])
+      objs = obj.get('object', [])
       if not isinstance(objs, list):
         objs = [objs]
-      ret['properties'][prop] = ret['properties'][prop + '-of'] = \
-          [o.get('url') for o in objs]
+      ret['properties'][prop + '-of'] = ret['properties'][prop] = [
+        o['url'] if 'url' in o and len(o) == 1
+        else object_to_json(o, trim_nulls=False, entry_class='h-cite')
+        for o in objs]
+
     else:
-      ret['properties'][prop] = [object_to_json(t, trim_nulls=False)
-                                 for t in act.get('tags', [])
-                                 if source.object_type(t) == type]
+      ret['properties'][prop] = [
+        object_to_json(t, trim_nulls=False, entry_class='h-cite')
+        for t in obj.get('tags', []) if source.object_type(t) == type]
 
   if trim_nulls:
     ret = util.trim_nulls(ret)
@@ -219,9 +216,9 @@ def json_to_object(mf2):
     ('h-as-rsvp', 'activity', rsvp_verb),
     ('h-as-repost', 'activity', 'share'),
     ('h-as-like', 'activity', 'like'),
-    ('p-comment', 'comment', None),
+    ('h-as-comment', 'comment', None),
     ('h-as-reply', 'comment', None),
-    ('p-location', 'place', None),
+    ('h-as-location', 'place', None),
     ('h-card', 'person', None),
     ]
 
@@ -321,7 +318,7 @@ def activities_to_html(activities):
   """ % '\n'.join(object_to_html(a) for a in activities)
 
 
-def object_to_html(obj):
+def object_to_html(obj, parent_prop=None):
   """Converts an ActivityStreams object to microformats2 HTML.
 
   Features:
@@ -337,16 +334,18 @@ def object_to_html(obj):
     converted to links if they have startIndex and length, otherwise added to
     the end.
   """
-  return json_to_html(object_to_json(obj))
+  return json_to_html(object_to_json(obj), parent_prop)
 
 
-def json_to_html(obj):
+def json_to_html(obj, parent_prop=None):
   """Converts a microformats2 JSON object to microformats2 HTML.
 
   See object_to_html for details.
 
   Args:
     obj: dict, a decoded microformats2 JSON object
+    parent_prop: string (optional), the property of the parent object where
+      this object is embedded, e.g. 'u-repost-of'
 
   Returns: string HTML
   """
@@ -355,7 +354,7 @@ def json_to_html(obj):
 
   # TODO: handle when h-card isn't first
   if obj['type'][0] == 'h-card':
-    return hcard_to_html(obj)
+    return hcard_to_html(obj, parent_prop)
 
   props = copy.copy(obj['properties'])
   in_reply_tos = '\n'.join(IN_REPLY_TO.substitute(url=url)
@@ -364,23 +363,30 @@ def json_to_html(obj):
   prop = first_props(props)
   prop.setdefault('uid', '')
   author = prop.get('author')
-  if author:
-    author['type'].append('p-author')
 
   # if this post is itself a like or repost, link to its target(s). (do this and
   # rsvp below *before* content since they set props['name'] if necessary.)
   likes_and_reposts = []
-  for verb in 'like', 'repost':
-    if ('h-as-%s' % verb) in obj['type']:
-      if not props.get('name'):
-        props['name'] = ['%ss this.' % verb]
-      likes_and_reposts += ['<a class="u-%s u-%s-of" href="%s"></a>' %
-                            (verb, verb, url) for url in props.get(verb)]
+  if 'h-as-like' in obj['type']:
+    if not props.get('name'):
+      props['name'] = ['likes this.']
+    likes_and_reposts += ['<a class="u-like u-like-of" href="%s"></a>' %
+                          url for url in props.get('like-of')]
+
+  if 'h-as-repost' in obj['type']:
+    if not props.get('name'):
+      props['name'] = ['reposts this.']
+    for repost in props.get('repost-of', []):
+      if isinstance(repost, dict):
+        likes_and_reposts.append(
+          json_to_html(repost, parent_prop='u-repost u-repost-of'))
+      else:
+        likes_and_reposts.append(
+          '<a class="u-repost u-repost-of" href="%s"></a>' % repost)
 
   # if this post is an rsvp, populate its data element. if it's an invite, give
   # it a default name.
   rsvp = prop.get('rsvp')
-  invitee = prop.get('rsvp')
   if rsvp:
     if not props.get('name'):
       props['name'] = [{'yes': 'is attending.',
@@ -412,26 +418,29 @@ def json_to_html(obj):
   # comments
   # http://indiewebcamp.com/comment-presentation#How_to_markup
   # http://indiewebcamp.com/h-cite
-  comments_html = '\n'.join(json_to_html(c) for c in props.get('comment', []))
+  comments_html = '\n'.join(json_to_html(c, parent_prop='p-comment')
+                            for c in props.get('comment', []))
 
   # embedded likes and reposts of this post
   # http://indiewebcamp.com/like, http://indiewebcamp.com/repost
   for verb in 'like', 'repost':
     vals = props.get(verb, [])
     if vals and isinstance(vals[0], dict):
-      likes_and_reposts += [json_to_html(v) for v in vals]
+      likes_and_reposts += [json_to_html(v, parent_prop='u-' + verb)
+                            for v in vals]
 
   return HENTRY.substitute(
     prop,
     published=maybe_datetime(prop.get('published'), 'dt-published'),
     updated=maybe_datetime(prop.get('updated'), 'dt-updated'),
-    types=' '.join(obj['type']),
-    author=hcard_to_html(author),
-    location=hcard_to_html(prop.get('location')),
+    types=' '.join(([parent_prop] if parent_prop else []) + obj['type']),
+    author=hcard_to_html(author, parent_prop='p-author'),
+    location=hcard_to_html(prop.get('location'), 'p-location'),
     photo=photo,
     video=video,
     in_reply_tos=in_reply_tos,
-    invitees='\n'.join([hcard_to_html(i) for i in props.get('invitee', [])]),
+    invitees='\n'.join([hcard_to_html(i, parent_prop='p-invitee')
+                        for i in props.get('invitee', [])]),
     content=content_html,
     content_classes=' '.join(content_classes),
     comments=comments_html,
@@ -440,7 +449,7 @@ def json_to_html(obj):
     summary=summary)
 
 
-def hcard_to_html(hcard):
+def hcard_to_html(hcard, parent_prop=None):
   """Renders an h-card as HTML.
 
   Args:
@@ -457,7 +466,7 @@ def hcard_to_html(hcard):
   photo = prop.get('photo')
   return HCARD.substitute(
     prop,
-    types=' '.join(hcard['type']),
+    types=' '.join(([parent_prop] if parent_prop else []) + hcard['type']),
     photo=img(photo, 'u-photo', '') if photo else '',
     linked_name=maybe_linked_name(hcard['properties']))
 
@@ -557,10 +566,9 @@ def render_content(obj, include_location=True):
   # location
   loc = obj.get('location')
   if include_location and loc:
-    loc_mf2 = object_to_json(loc)
-    # FIXME p-location is not a valid type, maybe h-as-location?
-    loc_mf2['type'] = ['h-card', 'p-location']
-    content += '\n' + hcard_to_html(loc_mf2)
+    content += '\n' + hcard_to_html(
+      object_to_json(loc, default_object_type='place'),
+      'p-location')
 
   # other tags, except likes and (re)shares. they're rendered manually in
   # json_to_html().

--- a/granary/test/test_facebook.py
+++ b/granary/test/test_facebook.py
@@ -677,7 +677,7 @@ Checking another side project off my list. portablecontacts-unofficial is live! 
 </a>
 <span class="summary">my link caption</span>
 </p>
-<div class="h-card p-location">
+<div class="p-location h-card h-as-location">
   <div class="p-name"><a class="u-url" href="https://www.facebook.com/113785468632283">Lake Merced</a></div>
 
 </div>

--- a/granary/test/test_instagram.py
+++ b/granary/test/test_instagram.py
@@ -396,7 +396,7 @@ this picture -&gt; is #abc #xyz
 <img class="thumbnail" src="http://attach/image/big" alt="" />
 </a>
 </p>
-<div class="h-card p-location">
+<div class="p-location h-card h-as-location">
   <div class="p-name"><a class="u-url" href="https://instagram.com/explore/locations/520640/">Le Truc</a></div>
 
 </div>

--- a/granary/test/test_microformats2.py
+++ b/granary/test/test_microformats2.py
@@ -85,9 +85,12 @@ class Microformats2Test(testutil.HandlerTest):
         'value': 'Entity < link too',
       }]},
      }, microformats2.object_to_json({
+       'verb': 'post',
+       'object': {
         'content': 'Entity &lt; link too',
         'tags': [{'url': 'http://my/link', 'startIndex': 12, 'length': 8}]
-      }))
+       }
+     }))
 
   def test_object_to_json_note_with_in_reply_to(self):
     self.assertEquals({
@@ -100,12 +103,15 @@ class Microformats2Test(testutil.HandlerTest):
         'in-reply-to': ['http://reply/target'],
       },
     }, microformats2.object_to_json({
+      'verb': 'post',
+      'object': {
         'content': '@hey great post',
-      }, ctx={
+      },
+      'context': {
         'inReplyTo': [{
           'url': 'http://reply/target',
-        }]
-      }))
+        }],
+      }}))
 
   def test_object_to_html_note_with_in_reply_to(self):
     expected = """\
@@ -118,11 +124,15 @@ class Microformats2Test(testutil.HandlerTest):
 </article>
 """
     result = microformats2.object_to_html({
-      'content': '@hey great post',
-    }, ctx={
-      'inReplyTo': [{
-        'url': 'http://reply/target',
-      }]
+      'verb': 'post',
+      'context': {
+        'inReplyTo': [{
+          'url': 'http://reply/target',
+        }],
+      },
+      'object': {
+        'content': '@hey great post',
+      }
     })
     self.assertEquals(re.sub('\n\s*', '\n', expected),
                       re.sub('\n\s*', '\n', result))
@@ -171,7 +181,7 @@ foo
   def test_render_content_location(self):
     self.assert_equals("""\
 foo
-<div class="h-card p-location">
+<div class="p-location h-card h-as-location">
   <div class="p-name"><a class="u-url" href="http://my/place">My place</a></div>
 
 </div>
@@ -188,7 +198,7 @@ foo
 <article class="h-entry">
 <span class="u-uid"></span>
 
-<div class="h-card p-author">
+<div class="p-author h-card">
 <div class="p-name">a " b ' c</div>
 <img class="u-photo" src="img" alt="" />
 </div>

--- a/granary/test/test_microformats2.py
+++ b/granary/test/test_microformats2.py
@@ -62,7 +62,7 @@ class Microformats2Test(testutil.HandlerTest):
     self.assertFalse(obj.get('image'))
 
   def test_nested_compound_url_object(self):
-    mf2 = {'type': ['h-as-repost'],
+    mf2 = {'type': ['h-as-share'],
            'properties': {
              'repost-of': [{
                'type': ['h-outer'],

--- a/granary/test/test_testdata.py
+++ b/granary/test/test_testdata.py
@@ -76,8 +76,9 @@ class TestDataTest(testutil.HandlerTest):
         else:
           expected = read_json(dst)
         try:
-          self.assert_equals(expected, fn(read_json(src)),
-                             '\n%s:1:\n' % os.path.abspath(dst))
+          self.assert_equals(
+            expected, fn(read_json(src)),
+            '\n%s %s:1:\n' % (fn.__name__, os.path.abspath(dst)))
         except AssertionError:
           logging.exception('')
           failed = True

--- a/granary/test/test_twitter.py
+++ b/granary/test/test_twitter.py
@@ -977,15 +977,18 @@ class TwitterTest(testutil.TestCase):
   def test_tweet_to_activity_on_retweet(self):
     self.assert_equals({
         'verb': 'share',
+        'url': 'https://twitter.com/',
         'object': {
           'objectType': 'note',
-          'content': 'RT <a href="https://twitter.com/orig_author">@orig_author</a>: my long original tweet',
+          'content': 'my long original tweet',
           }
         },
       self.twitter.tweet_to_activity({
         'id_str': '444',
         'text': 'truncated',
+        'user': {'id': 888, 'screen_name': 'rt_author'},
         'retweeted_status': {
+          'id_str': '333',
           'text': 'my long original tweet',
           'user': {'id': 777, 'screen_name': 'orig_author'},
           },

--- a/granary/test/test_twitter.py
+++ b/granary/test/test_twitter.py
@@ -517,7 +517,7 @@ ATOM = """\
 <img class="thumbnail" src="http://p.twimg.com/picture2" alt="" />
 </a>
 </p>
-<div class="h-card p-location">
+<div class="p-location h-card h-as-location">
 <div class="p-name"><a class="u-url" href="https://maps.google.com/maps?q=32.4004416,-98.9852672">Carcassonne, Aude</a></div>
 
 </div>
@@ -977,10 +977,29 @@ class TwitterTest(testutil.TestCase):
   def test_tweet_to_activity_on_retweet(self):
     self.assert_equals({
         'verb': 'share',
-        'url': 'https://twitter.com/',
+        'url': 'https://twitter.com/rt_author/status/444',
+        'actor': {
+            'displayName': 'rt_author',
+            'id': tag_uri('rt_author'),
+            'image': {'url': 'https://twitter.com/rt_author/profile_image?size=original'},
+            'objectType': 'person',
+            'url': 'https://twitter.com/rt_author',
+            'username': 'rt_author'
+          },
+        'id': tag_uri(444),
         'object': {
+          'author': {
+            'displayName': 'orig_author',
+            'id': tag_uri('orig_author'),
+            'image': {'url': 'https://twitter.com/orig_author/profile_image?size=original'},
+            'objectType': 'person',
+            'url': 'https://twitter.com/orig_author',
+            'username': 'orig_author'
+          },
           'objectType': 'note',
           'content': 'my long original tweet',
+          'id': tag_uri(333),
+          'url': 'https://twitter.com/orig_author/status/333',
           }
         },
       self.twitter.tweet_to_activity({

--- a/granary/test/testdata/article_with_comments.mf2.html
+++ b/granary/test/testdata/article_with_comments.mf2.html
@@ -6,10 +6,10 @@
 
   </div>
 
-<article class="h-entry p-comment">
+<article class="p-comment h-cite h-as-comment">
   <span class="u-uid"></span>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>
@@ -23,7 +23,7 @@
 
 </article>
 
-<article class="h-entry p-comment">
+<article class="p-comment h-cite h-as-comment">
   <span class="u-uid"></span>
 
   <div class="p-name"><a class="u-url" href="http://example.com/comment/2">second comment name</a></div>

--- a/granary/test/testdata/article_with_comments.mf2.json
+++ b/granary/test/testdata/article_with_comments.mf2.json
@@ -5,7 +5,7 @@
     "url": ["http://example.com/article-abc"],
 
     "comment": [{
-      "type": ["h-entry", "p-comment"],
+      "type": ["h-cite", "h-as-comment"],
       "properties": {
         "author": [{
           "type": ["h-card"],
@@ -15,7 +15,7 @@
         "in-reply-to": ["http://example.com/article-abc"]
       }
     }, {
-      "type": ["h-entry", "p-comment"],
+      "type": ["h-cite", "h-as-comment"],
       "properties": {
         "url": ["http://example.com/comment/2"],
         "name": ["second comment name"],

--- a/granary/test/testdata/article_with_likes.mf2.html
+++ b/granary/test/testdata/article_with_likes.mf2.html
@@ -6,10 +6,10 @@
 
   </div>
 
-<article class="h-entry h-as-like">
+<article class="u-like h-cite h-as-like">
   <span class="u-uid"></span>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>
@@ -23,7 +23,7 @@
 
 </article>
 
-<article class="h-entry h-as-like">
+<article class="u-like h-cite h-as-like">
   <span class="u-uid"></span>
 
   <div class="p-name"><a class="u-url" href="http://example.com/anonymous/like">likes this.</a></div>

--- a/granary/test/testdata/article_with_likes.mf2.json
+++ b/granary/test/testdata/article_with_likes.mf2.json
@@ -3,7 +3,7 @@
   "properties": {
     "url": ["http://example.com/abc"],
     "like": [{
-      "type": ["h-entry", "h-as-like"],
+      "type": ["h-cite", "h-as-like"],
       "properties": {
         "author": [{
           "type": ["h-card"],
@@ -17,7 +17,7 @@
         "like-of": ["http://example.com/abc"]
       }
     }, {
-      "type": ["h-entry", "h-as-like"],
+      "type": ["h-cite", "h-as-like"],
       "properties": {
         "url": ["http://example.com/anonymous/like"],
         "like": ["http://example.com/abc"],

--- a/granary/test/testdata/article_with_reposts.mf2.html
+++ b/granary/test/testdata/article_with_reposts.mf2.html
@@ -6,7 +6,7 @@
 
   </div>
 
-<article class="u-repost h-cite h-as-repost">
+<article class="u-repost h-cite h-as-share">
   <span class="u-uid"></span>
 
   <div class="p-author h-card">
@@ -23,7 +23,7 @@
 
 </article>
 
-<article class="u-repost h-cite h-as-repost">
+<article class="u-repost h-cite h-as-share">
   <span class="u-uid"></span>
 
   <div class="p-name"><a class="u-url" href="http://example.com/anonymous/repost">reposts this.</a></div>

--- a/granary/test/testdata/article_with_reposts.mf2.html
+++ b/granary/test/testdata/article_with_reposts.mf2.html
@@ -6,10 +6,10 @@
 
   </div>
 
-<article class="h-entry h-as-repost">
+<article class="u-repost h-cite h-as-repost">
   <span class="u-uid"></span>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>
@@ -23,7 +23,7 @@
 
 </article>
 
-<article class="h-entry h-as-repost">
+<article class="u-repost h-cite h-as-repost">
   <span class="u-uid"></span>
 
   <div class="p-name"><a class="u-url" href="http://example.com/anonymous/repost">reposts this.</a></div>

--- a/granary/test/testdata/article_with_reposts.mf2.json
+++ b/granary/test/testdata/article_with_reposts.mf2.json
@@ -3,7 +3,7 @@
   "properties": {
     "url": ["http://example.com/abc"],
     "repost": [{
-      "type": ["h-cite", "h-as-repost"],
+      "type": ["h-cite", "h-as-share"],
       "properties": {
         "author": [{
           "type": ["h-card"],
@@ -17,7 +17,7 @@
         "repost-of": ["http://example.com/abc"]
       }
     }, {
-      "type": ["h-cite", "h-as-repost"],
+      "type": ["h-cite", "h-as-share"],
       "properties": {
         "url": ["http://example.com/anonymous/repost"],
         "repost": ["http://example.com/abc"],

--- a/granary/test/testdata/article_with_reposts.mf2.json
+++ b/granary/test/testdata/article_with_reposts.mf2.json
@@ -3,7 +3,7 @@
   "properties": {
     "url": ["http://example.com/abc"],
     "repost": [{
-      "type": ["h-entry", "h-as-repost"],
+      "type": ["h-cite", "h-as-repost"],
       "properties": {
         "author": [{
           "type": ["h-card"],
@@ -17,7 +17,7 @@
         "repost-of": ["http://example.com/abc"]
       }
     }, {
-      "type": ["h-entry", "h-as-repost"],
+      "type": ["h-cite", "h-as-repost"],
       "properties": {
         "url": ["http://example.com/anonymous/repost"],
         "repost": ["http://example.com/abc"],

--- a/granary/test/testdata/comment.mf2.html
+++ b/granary/test/testdata/comment.mf2.html
@@ -1,4 +1,4 @@
-<article class="h-entry p-comment">
+<article class="h-entry h-as-comment">
   <span class="u-uid">tag:example.com,2001:547822715231468_6796480</span>
 
   <time class="dt-published" datetime="2012-12-05T00:58:26+00:00">2012-12-05T00:58:26+00:00</time>
@@ -9,7 +9,7 @@
   foo bar baz
   </div>
 
-  <div class="h-card p-location">
+  <div class="p-location h-card h-as-location">
     <div class="p-name"><a class="u-url" href="https://maps.google.com/maps?q=32.4004416,-98.9852672">Carcassonne, Aude</a></div>
 
   </div>

--- a/granary/test/testdata/comment.mf2.json
+++ b/granary/test/testdata/comment.mf2.json
@@ -1,5 +1,5 @@
 {
-  "type": ["h-entry", "p-comment"],
+  "type": ["h-entry", "h-as-comment"],
   "properties": {
     "uid": ["tag:example.com,2001:547822715231468_6796480"],
     "url": ["http://example.com/comment/547822715231468_6796480"],
@@ -7,7 +7,7 @@
     "content": [{"value": "foo bar baz", "html": "foo bar baz"}],
     "in-reply-to": ["http://example.com/original/post"],
     "location": [{
-      "type": ["h-card", "p-location"],
+      "type": ["h-card", "h-as-location"],
       "properties": {
         "uid": ["31cb9e7ed29dbe52"],
         "name": ["Carcassonne, Aude"],

--- a/granary/test/testdata/invite.mf2.html
+++ b/granary/test/testdata/invite.mf2.html
@@ -1,14 +1,14 @@
 <article class="h-entry">
   <span class="u-uid"></span>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/host">Mr. Host</a></div>
 
   </div>
 
   <div class="p-name"><a class="u-url" href="http://example.com/this/invite">invited</a></div>
   <div class="">
-  <div class="h-card p-invitee">
+  <div class="p-invitee h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>

--- a/granary/test/testdata/invite.mf2.json
+++ b/granary/test/testdata/invite.mf2.json
@@ -3,7 +3,7 @@
   "properties": {
     "url": ["http://example.com/this/invite"],
     "invitee": [{
-      "type": ["h-card", "p-invitee"],
+      "type": ["h-card"],
       "properties": {
         "name": ["Alice"],
         "url": ["http://example.com/alice"]

--- a/granary/test/testdata/like.mf2.html
+++ b/granary/test/testdata/like.mf2.html
@@ -3,7 +3,7 @@
 
   <time class="dt-published" datetime="2012-12-05T00:58:26+00:00">2012-12-05T00:58:26+00:00</time>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>

--- a/granary/test/testdata/like_multiple_urls.mf2.html
+++ b/granary/test/testdata/like_multiple_urls.mf2.html
@@ -3,7 +3,7 @@
 
   <time class="dt-published" datetime="2012-12-05T00:58:26+00:00">2012-12-05T00:58:26+00:00</time>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>

--- a/granary/test/testdata/note.mf2.html
+++ b/granary/test/testdata/note.mf2.html
@@ -3,7 +3,7 @@
   <div class="p-summary">too cool to summarize</div>
   <time class="dt-published" datetime="2012-02-22T20:26:41">2012-02-22T20:26:41</time>
   <time class="dt-updated" datetime="2013-10-25T10:31:30+00:00">2013-10-25T10:31:30+00:00</time>
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name">Ryan Barrett</div>
     <img class="u-photo" src="http://example.com/ryan/image" alt="" />
   </div>
@@ -17,7 +17,7 @@
   </div>
 
   <img class="u-photo" src="http://example.com/blog-post-123/image" alt="attachment" />
-  <div class="h-card p-location">
+  <div class="p-location h-card h-as-location">
     <div class="p-name"><a class="u-url" href="https://maps.google.com/maps?q=32.4004416,-98.9852672">Carcassonne, Aude</a></div>
 
   </div>

--- a/granary/test/testdata/note.mf2.json
+++ b/granary/test/testdata/note.mf2.json
@@ -25,7 +25,7 @@
     }],
 
     "location": [{
-      "type": ["h-card", "p-location"],
+      "type": ["h-card", "h-as-location"],
       "properties": {
         "uid": ["31cb9e7ed29dbe52"],
         "name": ["Carcassonne, Aude"],

--- a/granary/test/testdata/repost.mf2.html
+++ b/granary/test/testdata/repost.mf2.html
@@ -3,7 +3,7 @@
 
   <time class="dt-published" datetime="2012-12-05T00:58:26+00:00">2012-12-05T00:58:26+00:00</time>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>

--- a/granary/test/testdata/repost.mf2.html
+++ b/granary/test/testdata/repost.mf2.html
@@ -1,4 +1,4 @@
-<article class="h-entry h-as-repost">
+<article class="h-entry h-as-share">
   <span class="u-uid">tag:example.com,2001:3344</span>
 
   <time class="dt-published" datetime="2012-12-05T00:58:26+00:00">2012-12-05T00:58:26+00:00</time>

--- a/granary/test/testdata/repost.mf2.json
+++ b/granary/test/testdata/repost.mf2.json
@@ -1,5 +1,5 @@
 {
-  "type": ["h-entry", "h-as-repost"],
+  "type": ["h-entry", "h-as-share"],
   "properties": {
     "uid": ["tag:example.com,2001:3344"],
     "url": ["http://example.com/this/repost"],

--- a/granary/test/testdata/repost_of_with_h_cite.mf2.html
+++ b/granary/test/testdata/repost_of_with_h_cite.mf2.html
@@ -1,4 +1,4 @@
-<article class="h-entry h-as-repost">
+<article class="h-entry h-as-share">
   <section class="share-context">
     Repost of:
     <ul>

--- a/granary/test/testdata/rsvp.mf2.html
+++ b/granary/test/testdata/rsvp.mf2.html
@@ -1,7 +1,7 @@
 <article class="h-entry h-as-rsvp">
   <span class="u-uid"></span>
 
-  <div class="h-card p-author">
+  <div class="p-author h-card">
     <div class="p-name"><a class="u-url" href="http://example.com/alice">Alice</a></div>
 
   </div>

--- a/granary/twitter.py
+++ b/granary/twitter.py
@@ -192,7 +192,9 @@ class Twitter(source.Source):
       total_count = len(tweets)
     else:
       if group_id == source.SELF:
-        if user_id in (None, source.ME):
+        if user_id == source.ME:
+          user_id = None
+        if not user_id:
           url = API_SELF_TIMELINE_URL % (count + start_index)
         else:
           url = API_USER_TIMELINE_URL % {

--- a/granary/twitter.py
+++ b/granary/twitter.py
@@ -783,15 +783,19 @@ class Twitter(source.Source):
       an ActivityStreams activity dict, ready to be JSON-encoded
     """
     obj = self.tweet_to_object(tweet)
-    retweeted = tweet.get('retweeted_status')
     activity = {
-      'verb': 'share' if retweeted else 'post',
+      'verb': 'post',
       'published': obj.get('published'),
       'id': obj.get('id'),
       'url': obj.get('url'),
       'actor': obj.get('author'),
       'object': obj,
       }
+
+    retweeted = tweet.get('retweeted_status')
+    if retweeted:
+      activity['verb'] = 'share'
+      activity['object'] = self.tweet_to_object(retweeted)
 
     in_reply_to = obj.get('inReplyTo')
     if in_reply_to:

--- a/test_app.py
+++ b/test_app.py
@@ -10,12 +10,14 @@ import app
 
 
 ACTIVITIES = [{
+  'verb': 'post',
   'object': {
     'content': 'foo bar',
     'published': '2012-03-04T18:20:37+00:00',
     'url': 'https://perma/link',
   }
 }, {
+  'verb': 'post',
   'object': {
     'content': 'baz baj',
   },


### PR DESCRIPTION
- Use activity itself rather than the object when available
- Retweets include original status as the object of the activity
- p-* u-* properties are treated as properties rather than types
- Assign h-cite when parsing a nested context (rather than h-entry)
- Atom conversion prepends "Shared a post by..." (or "Liked a post by...") to the rendered content

Fixes #42 and #44