### PR TITLE
Mf2 moved repost context to render_content

### DIFF
--- a/granary/test/testdata/article_with_likes.mf2.html
+++ b/granary/test/testdata/article_with_likes.mf2.html
@@ -15,9 +15,11 @@
   </span>
 
   <div class="e-content p-name">
-    
-    <a class="u-like u-like-of" href="http://example.com/abc">likes this.</a>
+
+    <a href="http://example.com/abc">likes this.</a>
   </div>
+
+  <a class="u-like u-like-of" href="http://example.com/abc"></a>
 
 </article>
 
@@ -26,10 +28,11 @@
 
   <a class="u-url" href="http://example.com/anonymous/like">http://example.com/anonymous/like</a>
   <div class="e-content p-name">
-    
-    <a class="u-like u-like-of" href="http://example.com/abc">likes this.</a>
+
+    <a href="http://example.com/abc">likes this.</a>
   </div>
 
+  <a class="u-like u-like-of" href="http://example.com/abc"></a>
 
 </article>
 

--- a/granary/test/testdata/article_with_likes.mf2.json
+++ b/granary/test/testdata/article_with_likes.mf2.json
@@ -13,6 +13,7 @@
             "url": ["http://example.com/alice"]
           }
         }],
+        "content": [{"html": "<a href=\"http://example.com/abc\">likes this.</a>"}],
         "like": ["http://example.com/abc"],
         "like-of": ["http://example.com/abc"]
       }
@@ -20,6 +21,7 @@
       "type": ["h-cite", "h-as-like"],
       "properties": {
         "url": ["http://example.com/anonymous/like"],
+        "content": [{"html": "<a href=\"http://example.com/abc\">likes this.</a>"}],
         "like": ["http://example.com/abc"],
         "like-of": ["http://example.com/abc"]
       }

--- a/granary/test/testdata/article_with_reposts.mf2.html
+++ b/granary/test/testdata/article_with_reposts.mf2.html
@@ -16,8 +16,10 @@
 
   <div class="e-content p-name">
 
-    <a class="u-repost u-repost-of" href="http://example.com/abc">reposts this.</a>
+    <a href="http://example.com/abc">shared this.</a>
   </div>
+
+  <a class="u-repost u-repost-of" href="http://example.com/abc"></a>
 
 
 </article>
@@ -28,8 +30,10 @@
   <a class="u-url" href="http://example.com/anonymous/repost">http://example.com/anonymous/repost</a>
   <div class="e-content p-name">
 
-    <a class="u-repost u-repost-of" href="http://example.com/abc">reposts this.</a>
+    <a href="http://example.com/abc">shared this.</a>
   </div>
+
+  <a class="u-repost u-repost-of" href="http://example.com/abc"></a>
 
 
 </article>

--- a/granary/test/testdata/article_with_reposts.mf2.json
+++ b/granary/test/testdata/article_with_reposts.mf2.json
@@ -13,6 +13,7 @@
             "url": ["http://example.com/alice"]
           }
         }],
+        "content": [{"html": "<a href=\"http://example.com/abc\">shared this.</a>"}],
         "repost": ["http://example.com/abc"],
         "repost-of": ["http://example.com/abc"]
       }
@@ -20,6 +21,7 @@
       "type": ["h-cite", "h-as-share"],
       "properties": {
         "url": ["http://example.com/anonymous/repost"],
+        "content": [{"html": "<a href=\"http://example.com/abc\">shared this.</a>"}],
         "repost": ["http://example.com/abc"],
         "repost-of": ["http://example.com/abc"]
       }

--- a/granary/test/testdata/like.as-from-mf2.json
+++ b/granary/test/testdata/like.as-from-mf2.json
@@ -1,0 +1,14 @@
+{
+  "objectType": "activity",
+  "verb": "like",
+  "id": "tag:example.com,2001:98765",
+  "published": "2012-12-05T00:58:26+00:00",
+  "url": "http://example.com/this/like",
+  "content": "<a href=\"http://example.com/original/post\">likes this.</a>",
+  "object": {"url": "http://example.com/original/post"},
+  "actor": {
+    "objectType": "person",
+    "displayName": "Alice",
+    "url": "http://example.com/alice"
+  }
+}

--- a/granary/test/testdata/like.mf2.html
+++ b/granary/test/testdata/like.mf2.html
@@ -10,8 +10,10 @@
 
   <a class="u-url" href="http://example.com/this/like">http://example.com/this/like</a>
   <div class="e-content p-name">
-    
-    <a class="u-like u-like-of" href="http://example.com/original/post">likes this.</a>
+
+    <a href="http://example.com/original/post">likes this.</a>
   </div>
+
+  <a class="u-like u-like-of" href="http://example.com/original/post"></a>
 
 </article>

--- a/granary/test/testdata/like.mf2.json
+++ b/granary/test/testdata/like.mf2.json
@@ -4,6 +4,7 @@
     "uid": ["tag:example.com,2001:98765"],
     "url": ["http://example.com/this/like"],
     "published": ["2012-12-05T00:58:26+00:00"],
+    "content": [{"html": "<a href=\"http://example.com/original/post\">likes this.</a>"}],
     "like": ["http://example.com/original/post"],
     "like-of": ["http://example.com/original/post"],
     "author": [{

--- a/granary/test/testdata/like_multiple_urls.as-from-mf2.json
+++ b/granary/test/testdata/like_multiple_urls.as-from-mf2.json
@@ -1,0 +1,15 @@
+{
+  "objectType": "activity",
+  "verb": "like",
+  "id": "tag:example.com,2001:98765",
+  "published": "2012-12-05T00:58:26+00:00",
+  "url": "http://example.com/this/like",
+  "content": "<a href=\"http://example.com/original/post\">likes this.</a>",
+  "object": [{"url": "http://example.com/original/post"},
+             {"url": "http://example.com/other/post"}],
+  "actor": {
+    "objectType": "person",
+    "displayName": "Alice",
+    "url": "http://example.com/alice"
+  }
+}

--- a/granary/test/testdata/like_multiple_urls.mf2.html
+++ b/granary/test/testdata/like_multiple_urls.mf2.html
@@ -10,10 +10,11 @@
 
   <a class="u-url" href="http://example.com/this/like">http://example.com/this/like</a>
   <div class="e-content p-name">
-    
-    <a class="u-like u-like-of" href="http://example.com/original/post">likes this.</a>
-    <a class="u-like u-like-of" href="http://example.com/other/post"></a>
+
+    <a href="http://example.com/original/post">likes this.</a>
   </div>
 
+  <a class="u-like u-like-of" href="http://example.com/original/post"></a>
+  <a class="u-like u-like-of" href="http://example.com/other/post"></a>
 
 </article>

--- a/granary/test/testdata/like_multiple_urls.mf2.json
+++ b/granary/test/testdata/like_multiple_urls.mf2.json
@@ -4,6 +4,7 @@
     "uid": ["tag:example.com,2001:98765"],
     "url": ["http://example.com/this/like"],
     "published": ["2012-12-05T00:58:26+00:00"],
+    "content": [{"html": "<a href=\"http://example.com/original/post\">likes this.</a>"}],
     "like": ["http://example.com/original/post",
              "http://example.com/other/post"],
     "like-of": ["http://example.com/original/post",

--- a/granary/test/testdata/repost.as-from-mf2.json
+++ b/granary/test/testdata/repost.as-from-mf2.json
@@ -1,0 +1,23 @@
+{
+  "objectType": "activity",
+  "verb": "share",
+  "id": "tag:example.com,2001:3344",
+  "published": "2012-12-05T00:58:26+00:00",
+  "url": "http://example.com/this/repost",
+  "content": "Shared <a href=\"http://example.com/original/post\">a post</a> by   <span class=\"h-card\">\n    <a class=\"p-name u-url\" href=\"http://example.com/bob\">Bob</a>\n    \n  </span>\nThe original post",
+  "object": {
+    "author": {
+      "objectType": "person",
+      "displayName": "Bob",
+      "url": "http://example.com/bob"
+    },
+    "content": "The original post",
+    "url": "http://example.com/original/post",
+    "objectType": "article"
+  },
+  "actor": {
+    "objectType": "person",
+    "displayName": "Alice",
+    "url": "http://example.com/alice"
+  }
+}

--- a/granary/test/testdata/repost.mf2.html
+++ b/granary/test/testdata/repost.mf2.html
@@ -15,7 +15,7 @@
       <a class="p-name u-url" href="http://example.com/bob">Bob</a>
 
     </span>
-    <div>The original post</div>
+The original post
   </div>
 
   <article class="u-repost u-repost-of h-cite h-as-article">

--- a/granary/test/testdata/repost.mf2.json
+++ b/granary/test/testdata/repost.mf2.json
@@ -4,6 +4,9 @@
     "uid": ["tag:example.com,2001:3344"],
     "url": ["http://example.com/this/repost"],
     "published": ["2012-12-05T00:58:26+00:00"],
+    "content": [{
+      "html": "Shared <a href=\"http://example.com/original/post\">a post</a> by   <span class=\"h-card\">\n    <a class=\"p-name u-url\" href=\"http://example.com/bob\">Bob</a>\n    \n  </span>\nThe original post"
+    }],
     "repost": [{
       "type": ["h-cite", "h-as-article"],
       "properties": {


### PR DESCRIPTION
All I wanted to do was move the repost rendering into `render_content` so that we'd get the same HTML rendering in mf2 and Atom conversions without having to add special cases to both.

It ended up being more refactoring than I bargained for, but I'm happy with the result.