### PR TITLE
testdata: support asymmetric conversions

### DIFF
--- a/granary/microformats2.py
+++ b/granary/microformats2.py
@@ -581,10 +581,11 @@ def render_content(obj, include_location=True):
       content += '\n<span class="summary">%s</span>' % summary
     content += '\n</p>'
 
-  # share/like contexts
+  # generate share/like contexts if the activity does not have content
+  # of its own
   for as_type, verb in [('share', 'Shared'), ('like', 'Likes')]:
     obj_type = source.object_type(obj)
-    if obj_type != as_type or 'object' not in obj:
+    if obj_type != as_type or 'object' not in obj or 'content' in obj:
       continue
 
     targets = obj.get('object')
@@ -607,9 +608,7 @@ def render_content(obj, include_location=True):
         if obj_type == 'share' and 'url' in obj and re.search(
                 '^https?://(?:www\.|mobile\.)?twitter\.com/', obj.get('url')):
           content += 'RT <a href="%s">@%s</a> ' % (
-            target.get('url', '#'),
-            author.get('username'),
-          )
+            target.get('url', '#'), author.get('username'))
         else:
           # image looks bad in the simplified rendering
           author = {k: v for k, v in author.iteritems() if k != 'image'}

--- a/granary/test/test_testdata.py
+++ b/granary/test/test_testdata.py
@@ -49,23 +49,12 @@ os.chdir(os.path.join(os.path.dirname(__file__), 'testdata/'))
 
 # source extension, destination extension, conversion function, exclude prefix
 mappings = (
-  ('as.json', ['mf2.json'], microformats2.object_to_json,
-   # as and mf2 do not have feature parity for these types, some
-   # info is lost in translation.
-   # TODO support asymmetric comparisons (possibly: extension types
-   # like .mf2-from-as.json would supersede .mf2.json if present)
-   ('in_reply_to', 'repost_of_with_h_cite', 'nested_author',
-    'note_with_composite_photo')),
-  ('as.json', ['mf2.html'], microformats2.object_to_html,
-   ('in_reply_to', 'repost_of_with_h_cite', 'nested_author',
-    #  'note_with_composite_photo'
-    )),  # see above
-  ('mf2.json', ['as-from-mf2.json', 'as.json'], microformats2.json_to_object,
-   # these have tags, which we don't generate
-   ('note.', 'article_with_')),
-  ('mf2.json', ['mf2.html'], microformats2.json_to_html,
-   ('in_reply_to', 'repost_of_with_h_cite', 'nested_author',
-    'note_with_composite_photo')),  # see above
+  ('as.json', ['mf2-from-as.json', 'mf2.json'], microformats2.object_to_json, ()),
+  ('as.json', ['mf2-from-as.html', 'mf2.html'], microformats2.object_to_html, ()),
+  ('mf2.json', ['as-from-mf2.json', 'as.json'], microformats2.json_to_object, ()),
+  ('mf2.json', ['mf2-from-json.html', 'mf2.html'], microformats2.json_to_html,
+   # we do not format h-media photos properly in html
+   ('note_with_composite_photo',)),
 )
 
 test_funcs = {}
@@ -81,8 +70,8 @@ for src_ext, dst_exts, fn, excludes in mappings:
     original = read_json(src)
 
     test_name = (
-      'test__%s__%s__%s' % (fn.__name__, src, dst)
-    ).replace('.', '_').replace('-', '_')
+      'test_%s_%s' % (fn.__name__, src[:-len(src_ext)])
+    ).replace('.', '_').replace('-', '_').strip('_')
     test_funcs[test_name] = create_test_function(fn, original, expected)
 
 os.chdir(prevdir)

--- a/granary/test/testdata/article_with_comments.as-from-mf2.json
+++ b/granary/test/testdata/article_with_comments.as-from-mf2.json
@@ -12,12 +12,11 @@
         "objectType": "person"
       },
       "content": "I concur.",
-      "inReplyTo": [{"id": "tag:example.com,2013:212038"},
-                    {"url": "http://example.com/article-abc"}]
+      "inReplyTo": [{"url": "http://example.com/article-abc"}]
     }, {
       "objectType": "comment",
       "url": "http://example.com/comment/2",
-      "title": "second comment name",
+      "displayName": "second comment name",
       "content": "And I, as well, in addition. Too.",
       "inReplyTo": [{"url": "http://example.com/article-def"},
                     {"url": "http://example.com/article-ghi"}]

--- a/granary/test/testdata/article_with_likes.as-from-mf2.json
+++ b/granary/test/testdata/article_with_likes.as-from-mf2.json
@@ -1,0 +1,4 @@
+{
+  "objectType": "article",
+  "url": "http://example.com/abc"
+}

--- a/granary/test/testdata/article_with_reposts.as-from-mf2.json
+++ b/granary/test/testdata/article_with_reposts.as-from-mf2.json
@@ -1,0 +1,4 @@
+{
+  "objectType": "article",
+  "url": "http://example.com/abc"
+}

--- a/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-as.html
+++ b/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-as.html
@@ -1,0 +1,12 @@
+<article class="h-entry h-as-comment">
+  <span class="p-uid"></span>
+
+  <div class="e-content p-name">
+
+    This is the main content.
+  </div>
+
+  <a class="u-in-reply-to" href="http://example.com/bare-reply"></a>
+  <a class="u-in-reply-to" href="http://example.com/embedded-reply"></a>
+
+</article>

--- a/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-as.json
+++ b/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-as.json
@@ -1,0 +1,11 @@
+{
+  "type" : ["h-entry", "h-as-comment"],
+  "properties" : {
+    "in-reply-to" : ["http://example.com/bare-reply",
+                     "http://example.com/embedded-reply"],
+    "content" : [{
+        "html" : "This is the main content.",
+        "value" : "This is the main content."
+      }]
+  }
+}

--- a/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-json.html
+++ b/granary/test/testdata/in_reply_to_with_h_cite.mf2-from-json.html
@@ -1,0 +1,12 @@
+<article class="h-entry">
+  <span class="p-uid"></span>
+
+  <div class="e-content p-name">
+
+    This is the main content.
+  </div>
+
+  <a class="u-in-reply-to" href="http://example.com/bare-reply"></a>
+  <a class="u-in-reply-to" href="http://example.com/embedded-reply"></a>
+
+</article>

--- a/granary/test/testdata/nested_author.mf2-from-as.html
+++ b/granary/test/testdata/nested_author.mf2-from-as.html
@@ -1,0 +1,4 @@
+<span class="h-card">
+  <span class="p-name">Foo Bar</span>
+
+</span>

--- a/granary/test/testdata/nested_author.mf2-from-as.json
+++ b/granary/test/testdata/nested_author.mf2-from-as.json
@@ -1,0 +1,6 @@
+{
+  "type": ["h-card"],
+  "properties": {
+    "name": ["Foo Bar"]
+  }
+}

--- a/granary/test/testdata/nested_author.mf2-from-json.html
+++ b/granary/test/testdata/nested_author.mf2-from-json.html
@@ -1,0 +1,4 @@
+<span class="h-card">
+  <span class="p-name">Foo Bar</span>
+
+</span>

--- a/granary/test/testdata/nested_author.mf2.json
+++ b/granary/test/testdata/nested_author.mf2.json
@@ -1,8 +1,7 @@
 {
   "type": ["h-card"],
-    "properties": {
-      "name": ["Foo Bar"],
-      "author": ["Foo Bar"]
-    },
-  "value": "Posted by Foo Bar"
+  "properties": {
+    "name": ["Foo Bar"],
+    "author": ["Foo Bar"]
+  }
 }

--- a/granary/test/testdata/note.as-from-mf2.json
+++ b/granary/test/testdata/note.as-from-mf2.json
@@ -1,0 +1,23 @@
+{
+  "objectType": "note",
+  "displayName": "blog post 123",
+  "summary": "too cool to summarize",
+  "content": "A blog post. <a href=\"http://my/link\">link</a> too",
+  "id": "tag:example.com,2011:blog-post-123",
+  "published": "2012-02-22T20:26:41",
+  "updated": "2013-10-25T10:31:30+00:00",
+  "url": "http://example.com/blog-post-123",
+  "image": {"url": "http://example.com/blog-post-123/image"},
+  "author": {
+    "id": "tag:example.com,2001:ryan",
+    "displayName": "Ryan Barrett",
+    "image": {"url": "http://example.com/ryan/image"},
+    "objectType": "person"
+  },
+  "location": {
+    "displayName": "Carcassonne, Aude",
+    "id": "31cb9e7ed29dbe52",
+    "url": "https://maps.google.com/maps?q=32.4004416,-98.9852672",
+    "objectType": "place"
+  }
+}

--- a/granary/test/testdata/note_with_composite_photo.mf2-from-as.json
+++ b/granary/test/testdata/note_with_composite_photo.mf2-from-as.json
@@ -1,0 +1,6 @@
+{
+  "type": ["h-entry", "h-as-note"],
+  "properties": {
+    "photo": ["https://ben.thatmustbe.me/static/img.jpg"]
+  }
+}

--- a/granary/test/testdata/repost_of_with_h_cite.mf2-from-as.html
+++ b/granary/test/testdata/repost_of_with_h_cite.mf2-from-as.html
@@ -1,0 +1,21 @@
+<article class="h-entry h-as-share">
+  <span class="p-uid"></span>
+
+  <div class="e-content p-name">
+
+    This is the main content.
+  </div>
+
+  <a class="u-repost u-repost-of" href="http://example.com/bare-repost"></a>
+  <article class="u-repost u-repost-of h-cite h-as-article">
+    <span class="p-uid"></span>
+
+    <a class="p-name u-url" href="http://example.com/embedded-repost">Author</a>
+    <div class="e-content">
+
+      Repost inside h-cite
+    </div>
+
+  </article>
+
+</article>

--- a/granary/test/testdata/repost_of_with_h_cite.mf2-from-as.json
+++ b/granary/test/testdata/repost_of_with_h_cite.mf2-from-as.json
@@ -1,0 +1,30 @@
+{
+  "type" : ["h-entry", "h-as-share"],
+  "properties" : {
+    "repost" : [
+      "http://example.com/bare-repost",
+      {
+        "type": ["h-cite", "h-as-article"],
+        "properties": {
+          "name": ["Author"],
+          "content": [{"html": "Repost inside h-cite", "value": "Repost inside h-cite"}],
+          "url": ["http://example.com/embedded-repost"]
+        }
+      }
+    ],
+    "repost-of" : [
+      "http://example.com/bare-repost",
+      {
+        "type": ["h-cite", "h-as-article"],
+        "properties": {
+          "name": ["Author"],
+          "content": [{"html": "Repost inside h-cite", "value": "Repost inside h-cite"}],
+          "url": ["http://example.com/embedded-repost"]
+        }
+      }],
+    "content" : [{
+      "html" : "This is the main content.",
+      "value" : "This is the main content."
+    }]
+  }
+}

--- a/granary/test/testdata/repost_of_with_h_cite.mf2-from-json.html
+++ b/granary/test/testdata/repost_of_with_h_cite.mf2-from-json.html
@@ -1,0 +1,21 @@
+<article class="h-entry">
+  <span class="p-uid"></span>
+
+  <div class="e-content p-name">
+
+    This is the main content.
+  </div>
+
+  <a class="u-repost u-repost-of" href="http://example.com/bare-repost"></a>
+  <article class="u-repost u-repost-of h-cite h-as-article">
+    <span class="p-uid"></span>
+
+    <a class="p-name u-url" href="http://example.com/embedded-repost">Author</a>
+    <div class="e-content">
+
+      Repost inside h-cite
+    </div>
+
+  </article>
+
+</article>

--- a/granary/test/testdata/repost_of_with_h_cite.mf2.json
+++ b/granary/test/testdata/repost_of_with_h_cite.mf2.json
@@ -9,7 +9,7 @@
         "properties" : {
           "url" : ["http://example.com/embedded-repost"],
           "name" : ["Author"],
-          "content" : ["Repost inside h-cite"]
+          "content" : [{"html": "Repost inside h-cite"}]
         }
       }
     ],


### PR DESCRIPTION
add support for new extensions that override the primary extension,
e.g. mf2-from-as.json will supersede mf2.json when converting object_to_json