### PR TITLE
Process AS content as HTML

### DIFF
--- a/granary/facebook.py
+++ b/granary/facebook.py
@@ -480,33 +480,37 @@ class Facebook(source.Source):
     data = self.urlopen(API_RSVP % (event_id, user_id)).get('data', [])
     return self.rsvp_to_object(data[0], event={'id': event_id}) if data else None
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     """Creates a new post, comment, like, or RSVP.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose contents will be a dict with 'id' and
       'url' keys for the newly created Facebook object (or None)
     """
-    return self._create(obj, preview=False, include_link=include_link)
+    return self._create(obj, preview=False, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     """Previews creating a new post, comment, like, or RSVP.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose contents will be a unicode string HTML snippet
       or None
     """
-    return self._create(obj, preview=True, include_link=include_link)
+    return self._create(obj, preview=True, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, preview=None, include_link=False):
+  def _create(self, obj, preview=None, include_link=False, ignore_formatting=False):
     """Creates a new post, comment, like, or RSVP.
 
     https://developers.facebook.com/docs/graph-api/reference/user/feed#publish
@@ -539,7 +543,7 @@ class Facebook(source.Source):
       base_url = base_obj['url'] = self.object_url(base_id)
 
     image_url = obj.get('image', {}).get('url')
-    content = self._content_for_create(obj) or ''
+    content = self._content_for_create(obj, ignore_formatting=ignore_formatting) or ''
     if not content and not image_url:
       if type == 'activity':
         content = verb

--- a/granary/flickr.py
+++ b/granary/flickr.py
@@ -75,12 +75,13 @@ class Flickr(source.Source):
     return flickr_auth.upload(
       params, photo_file, self.access_token_key, self.access_token_secret)
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     """Creates a photo, comment, or favorite.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose content will be a dict with 'id', 'url',
@@ -88,9 +89,10 @@ class Flickr(source.Source):
       object (or None)
 
     """
-    return self._create(obj, preview=False, include_link=include_link)
+    return self._create(obj, preview=False, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     """Preview creation of a photo, comment, or favorite.
 
     Args:
@@ -102,9 +104,10 @@ class Flickr(source.Source):
       what publishing will do, and whose content will be an HTML preview
       of the result (or None)
     """
-    return self._create(obj, preview=True, include_link=include_link)
+    return self._create(obj, preview=True, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, preview, include_link):
+  def _create(self, obj, preview, include_link, ignore_formatting=False):
     """Creates or previews creating for the previous two methods.
 
     https://www.flickr.com/services/api/upload.api.html
@@ -123,7 +126,7 @@ class Flickr(source.Source):
     # photo, comment, or like
     type = source.object_type(obj)
     logging.debug('publishing object type %s to Flickr', type)
-    content = self._content_for_create(obj)
+    content = self._content_for_create(obj, ignore_formatting=ignore_formatting)
     link_text = '(Originally published at: %s)' % obj.get('url')
 
     if obj.get('image') and type in ('note', 'article'):

--- a/granary/instagram.py
+++ b/granary/instagram.py
@@ -202,19 +202,21 @@ class Instagram(source.Source):
     """
     return None
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     """Creates a new comment or like.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns: a CreationResult. if successful, content will have and 'id' and
              'url' keys for the newly created Instagram object
     """
-    return self._create(obj, include_link=include_link, preview=False)
+    return self._create(obj, include_link=include_link, preview=False,
+                        ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     """Preview a new comment or like.
 
     Args:
@@ -224,9 +226,10 @@ class Instagram(source.Source):
     Returns: a CreationResult. if successful, content and description
              will describe the new instagram object.
     """
-    return self._create(obj, include_link=include_link, preview=True)
+    return self._create(obj, include_link=include_link, preview=True,
+                        ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, include_link=False, preview=None):
+  def _create(self, obj, include_link=False, preview=None, ignore_formatting=False):
     """Creates a new comment or like.
 
     The OAuth access token must have been created with scope=comments+likes (or
@@ -267,6 +270,7 @@ class Instagram(source.Source):
           error_plain='Cannot publish comments on Instagram',
           error_html='<a href="http://instagram.com/developer/endpoints/comments/#post_media_comments">Cannot publish comments</a> on Instagram. The Instagram API technically supports creating comments, but <a href="http://stackoverflow.com/a/26889101/682648">anecdotal</a> <a href="http://stackoverflow.com/a/20229275/682648">evidence</a> suggests they are very selective about which applications they approve to do so.')
       content = obj.get('content', '').encode('utf-8')
+      content = content if ignore_formatting else self._html_to_text(content)
       if preview:
         return source.creation_result(
           content=content,

--- a/granary/source.py
+++ b/granary/source.py
@@ -18,6 +18,7 @@ import logging
 import mimetypes
 import re
 import urlparse
+import html2text
 
 import requests
 
@@ -217,7 +218,7 @@ class Source(object):
             'updatedSince': False,
             }
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     """Creates a new object: a post, comment, like, share, or RSVP.
 
     Subclasses should override this. Different sites will support different
@@ -229,6 +230,8 @@ class Source(object):
         objectType is strongly recommended.
       include_link: boolean. If True, includes a link to the object
         (if it has one) in the content.
+      ignore_formatting: whether to use content text as is, instead of
+        converting its HTML to plain text styling (newlines, etc.)
 
     Returns:
       a CreationResult, whose contents will be a dict
@@ -239,7 +242,7 @@ class Source(object):
     """
     raise NotImplementedError()
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     """Previews creating a new object: a post, comment, like, share, or RSVP.
 
     Returns HTML that previews what create() with the same object will do.
@@ -253,6 +256,8 @@ class Source(object):
         objectType is strongly recommended.
       include_link: boolean. If True, includes a link to the object
         (if it has one) in the content.
+      ignore_formatting: whether to use content text as is, instead of
+        converting its HTML to plain text styling (newlines, etc.)
 
     Returns:
       a CreationResult, whose contents will be a unicode string
@@ -701,17 +706,18 @@ class Source(object):
     """
     return urlparse.urlparse(url).path.rstrip('/').rsplit('/', 1)[-1] or None
 
-  def _content_for_create(self, obj):
+  def _content_for_create(self, obj, ignore_formatting=False):
     """Returns the content text to use in create() and preview_create().
 
-    If objectType is note, or it's a comment (or there's an inReplyTo) and the
-    original post is on this source, then returns summary if available, then
-    content, then displayName.
+    returns summary if available, then content, then displayName.
 
-    Otherwise, returns summary if available, then displayName, then content.
+    If usig content, renders the HTML content to text using html2text so
+    that whitespace is formatted like in the browser.
 
     Args:
       obj: dict, ActivityStreams object
+      ignore_formatting: whether to use content text as is, instead of
+        converting its HTML to plain text styling (newlines, etc.)
 
     Returns: string text or None
     """
@@ -719,9 +725,21 @@ class Source(object):
     name = obj.get('displayName')
     content = obj.get('content')
 
-    ret = summary or content or name
-    return ret.strip() if ret else None
+    ret = summary or \
+          (content if ignore_formatting else self._html_to_text(content)) or \
+          name
+    return ret.strip() if ret else (None if content is None else u'')
 
+  def _html_to_text(self, html):
+    if html:
+      h = html2text.HTML2Text()
+      h.unicode_snob = True
+      h.body_width = 0  # don't wrap lines
+      h.ignore_links = True
+      h.ignore_images = True
+      return '\n'.join(
+        # strip trailing whitespace that html2text adds to ends of some lines
+        line.rstrip() for line in h.unescape(h.handle(html)).splitlines())
 
 def follow_redirects(url, cache=None, **kwargs):
   """Fetches a URL with HEAD, repeating if necessary to follow redirects.

--- a/granary/test/test_instagram.py
+++ b/granary/test/test_instagram.py
@@ -648,6 +648,7 @@ class InstagramTest(testutil.HandlerTest):
   def test_preview_comment(self):
     # comment obj doesn't have a url prior to publishing
     to_publish = copy.deepcopy(COMMENT_OBJS[0])
+    to_publish['content'] = 'very<br />cute'
     del to_publish['url']
 
     self.mox.ReplayAll()
@@ -656,7 +657,7 @@ class InstagramTest(testutil.HandlerTest):
 
     self.assertIn('comment', preview.description)
     self.assertIn('this post', preview.description)
-    self.assertIn('very cute', preview.content)
+    self.assertIn('very\ncute', preview.content)
 
   def test_create_comment(self):
     self.expect_urlopen(

--- a/granary/test/test_source.py
+++ b/granary/test/test_source.py
@@ -270,10 +270,10 @@ class SourceTest(testutil.TestCase):
                        self.source.base_object(like))
 
   def test_content_for_create(self):
-    def cfc(base, extra):
+    def cfc(base, extra, ignore_formatting=False):
       obj = base.copy()
       obj.update(extra)
-      return self.source._content_for_create(obj)
+      return self.source._content_for_create(obj, ignore_formatting=ignore_formatting)
 
     self.assertEqual(None, cfc({}, {}))
 
@@ -285,6 +285,7 @@ class SourceTest(testutil.TestCase):
       self.assertEqual('c', cfc(base, {'content': 'c', 'displayName': 'n'}))
       self.assertEqual('s', cfc(base, {'content': 'c', 'displayName': 'n',
                                        'summary': 's'}))
+      self.assertEqual('c<a&b\nhai', cfc(base, {'content': 'c<a&b\nhai'}, ignore_formatting=True))
 
     for base in ({'objectType': 'note'},
                  {'inReplyTo': {'url': 'http://fake.com/post'}},

--- a/granary/test/test_twitter.py
+++ b/granary/test/test_twitter.py
@@ -1100,6 +1100,7 @@ class TwitterTest(testutil.TestCase):
       'trailing slash http://www.foo.co/',
       'exactly twenty chars',
       'just over twenty one chars',  # would trunc after 'one' if we didn't account for the ellipsis
+      'HTML<br/>h &amp; h'
     )
     created = (
       'my status',
@@ -1110,6 +1111,7 @@ class TwitterTest(testutil.TestCase):
       'trailing slash http://www.foo.co/',
       'exactly twenty chars',
       'just over twenty' + dots,
+      'HTML\nh & h'
     )
     previewed = (
       'my status',
@@ -1120,6 +1122,7 @@ class TwitterTest(testutil.TestCase):
       'trailing slash <a href="http://www.foo.co/">foo.co</a>',
       'exactly twenty chars',
       'just over twenty' + dots,
+      'HTML\nh & h'
     )
 
     for content in created:
@@ -1246,7 +1249,7 @@ class TwitterTest(testutil.TestCase):
 
     obj = copy.deepcopy(OBJECT)
     del obj['image']
-    obj['content'] = orig
+    obj['content'] = orig.replace("\n", '<br />').replace('&', '&amp;')
     obj['url'] = 'http://tantek.com/2015/013/t1/names-ind-ie-indie-vc-not-indieweb'
 
     actual_preview = self.twitter.preview_create(obj, include_link=False).content
@@ -1313,7 +1316,7 @@ class TwitterTest(testutil.TestCase):
         'objectType': 'article',
         'summary': 'my summary',
         'displayName': 'my name',
-        'content': 'my content',
+        'content': 'my<br />content',
         'image': None,
         })
     result = self.twitter.preview_create(obj)
@@ -1325,7 +1328,7 @@ class TwitterTest(testutil.TestCase):
 
     del obj['displayName']
     result = self.twitter.preview_create(obj)
-    self.assertIn('my content', result.content)
+    self.assertIn('my\ncontent', result.content)
 
   def test_create_tweet_include_link(self):
     twitter.MAX_TWEET_LENGTH = 20
@@ -1369,7 +1372,7 @@ class TwitterTest(testutil.TestCase):
         ],
         "content": [
           {
-            "html": "https://instagram.com/p/9XVBIRA9cj/\n\nSocial Web session @W3C #TPAC2015 in Sapporo, Hokkaido, Japan.",
+            "html": "https://instagram.com/p/9XVBIRA9cj/<br /><br />Social Web session @W3C #TPAC2015 in Sapporo, Hokkaido, Japan.",
             "value": " https://instagram.com/p/9XVBIRA9cj/Social Web session @W3C #TPAC2015 in Sapporo, Hokkaido, Japan."
           }
         ],

--- a/granary/twitter.py
+++ b/granary/twitter.py
@@ -396,12 +396,13 @@ class Twitter(source.Source):
     url = API_STATUS_URL % share_id
     return self.retweet_to_object(self.urlopen(url))
 
-  def create(self, obj, include_link=False):
+  def create(self, obj, include_link=False, ignore_formatting=False):
     """Creates a tweet, reply tweet, retweet, or favorite.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose content will be a dict with 'id', 'url',
@@ -409,22 +410,25 @@ class Twitter(source.Source):
       object (or None)
 
     """
-    return self._create(obj, preview=False, include_link=include_link)
+    return self._create(obj, preview=False, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False):
+  def preview_create(self, obj, include_link=False, ignore_formatting=False):
     """Previews creating a tweet, reply tweet, retweet, or favorite.
 
     Args:
       obj: ActivityStreams object
       include_link: boolean
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose content will be a unicode string HTML
       snippet (or None)
     """
-    return self._create(obj, preview=True, include_link=include_link)
+    return self._create(obj, preview=True, include_link=include_link,
+                        ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, preview=None, include_link=False):
+  def _create(self, obj, preview=None, include_link=False, ignore_formatting=False):
     """Creates or previews creating a tweet, reply tweet, retweet, or favorite.
 
     https://dev.twitter.com/docs/api/1.1/post/statuses/update
@@ -454,7 +458,7 @@ class Twitter(source.Source):
     is_reply = type == 'comment' or 'inReplyTo' in obj
     has_picture = obj.get('image') and (type in ('note', 'article') or is_reply)
 
-    content = self._content_for_create(obj)
+    content = self._content_for_create(obj, ignore_formatting=ignore_formatting)
     if not content:
       if type == 'activity':
         content = verb
@@ -698,22 +702,22 @@ class Twitter(source.Source):
       content += ' (%s)' % include_url
     return content
 
-  def _content_for_create(self, obj):
+  def _content_for_create(self, obj, ignore_formatting=False):
     """Returns the content text to use in create() and preview_create().
 
     Differs from Source._content_for_create() in that it prefers displayName
     over content for articles. Otherwise it's the same.
     """
     type = obj.get('objectType')
+    base_url = self.base_object(obj).get('url')
+    if type == 'note' or (base_url and (type == 'comment' or obj.get('inReplyTo'))):
+        return source.Source._content_for_create(self, obj, ignore_formatting=ignore_formatting)
+
     summary = obj.get('summary')
     name = obj.get('displayName')
     content = obj.get('content')
-    base_url = self.base_object(obj).get('url')
 
-    if type == 'note' or (base_url and (type == 'comment' or obj.get('inReplyTo'))):
-      ret = summary or content or name
-    else:
-      ret = summary or name or content
+    ret = summary or name or (content if ignore_formatting else self._html_to_text(content))
 
     return ret.strip() if ret else None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mf2py>=0.2.6
 mf2util>=0.2.9
 oauth-dropins
 requests<2.6.0
+html2text


### PR DESCRIPTION
We produce it as HTML, and now we consume it as HTML.  This allows
more control over silo-specific formatting, but more importantly allows
us to implement silos that support HTML formatting (such as medium).

See also: https://github.com/snarfed/bridgy/pull/557