### PR TITLE
Add latitude and longitude to mf2->AS object conversion

### DIFF
--- a/granary/microformats2.py
+++ b/granary/microformats2.py
@@ -6,6 +6,7 @@ Microformats2 specs: http://microformats.org/wiki/microformats2
 from collections import deque
 import copy
 import itertools
+import logging
 import urlparse
 import string
 import re
@@ -245,6 +246,7 @@ def json_to_object(mf2):
     ('h-as-article', 'article'),
     ('h-as-note', 'note'),
     ('h-as-location', 'location'),
+    ('h-geo', 'location'),
     ('h-card', 'person'),
   ]
 
@@ -292,6 +294,17 @@ def json_to_object(mf2):
     'replies': {'items': [json_to_object(c) for c in props.get('comment', [])]},
     'tags': [json_to_object(cat) for cat in props.get('category', [])],
   }
+
+  lat, lng = prop.get('latitude'), prop.get('longitude')
+  if lat and lng:
+    try:
+      lat, lng = float(lat), float(lng)
+      # 2 leading places for latitude, 3 for longitude
+      obj['position'] = '%0+10.6f%0+11.6f/' % (lat, lng)
+      obj['latitude'], obj['longitude'] = lat, lng
+    except ValueError:
+      logging.warn(
+        'Could not convert latitude/longitude (%s, %s) to decimal', lat, lng)
 
   if as_type == 'activity':
     objects = []

--- a/granary/test/test_microformats2.py
+++ b/granary/test/test_microformats2.py
@@ -278,3 +278,23 @@ foo
   def test_json_to_html_no_properties_or_type(self):
     # just check that we don't crash
     microformats2.json_to_html({'x': 'y'})
+
+  def test_json_to_object_with_location(self):
+    obj = microformats2.json_to_object({
+      'type': ['h-entry'],
+      'properties': {
+        'location': [{
+          'type': ['h-geo'],
+          'properties': {
+            'latitude': ['50.820641'],
+            'longitude': ['-0.149522'],
+          }
+        }],
+      },
+    })
+    self.assertEquals({
+      'position': '+50.820641-000.149522/',
+      'latitude': 50.820641,
+      'longitude': -0.149522,
+      'objectType': 'place',
+    }, obj.get('location'))


### PR DESCRIPTION
Converts .h-entry > .p-location.h-geo to a proper ActivityStreams object with a location
that has latitude and longitude.

In the AS1 spec, location doesn't really seem to be an "object" per se, but it seems
like a convenient simplification to treat it as one