### PR TITLE
add hub= query param for atom output. fixes #53

### DIFF
--- a/activitystreams.py
+++ b/activitystreams.py
@@ -150,12 +150,17 @@ class Handler(webapp2.RequestHandler):
       self.response.out.write(json.dumps(response, indent=2))
     elif format == 'atom':
       self.response.headers['Content-Type'] = 'text/xml'
+      hub = self.request.get('hub')
       self.response.out.write(atom.activities_to_atom(
         activities, actor,
         host_url=url or self.request.host_url + '/',
-        request_url=self.request.path_url,
+        request_url=self.request.url,
         xml_base=util.base_url(url),
-        title=title))
+        title=title,
+        rels={'hub': hub} if hub else None))
+      self.response.headers.add('Link', str('<%s>; rel="self"' % self.request.url))
+      if hub:
+        self.response.headers.add('Link', str('<%s>; rel="hub"' % hub))
     elif format == 'xml':
       self.response.headers['Content-Type'] = 'text/xml'
       self.response.out.write(XML_TEMPLATE % util.to_xml(response))

--- a/granary/atom.py
+++ b/granary/atom.py
@@ -27,7 +27,7 @@ def _encode_ampersands(text):
 
 
 def activities_to_atom(activities, actor, title=None, request_url=None,
-                       host_url=None, xml_base=None):
+                       host_url=None, xml_base=None, rels=None):
   """Converts ActivityStreams activites to an Atom feed.
 
   Args:
@@ -38,6 +38,7 @@ def activities_to_atom(activities, actor, title=None, request_url=None,
     host_url: the home URL for this Atom feed, if any. Used in the top-level
       feed <id> element.
     xml_base: the base URL, if any. Used in the top-level xml:base attribute.
+    rels: rel links to include. dict mapping string rel value to string URL.
 
   Returns: unicode string with Atom XML
   """
@@ -103,6 +104,7 @@ def activities_to_atom(activities, actor, title=None, request_url=None,
     title=title or 'User feed for ' + source.Source.actor_name(actor),
     updated=activities[0]['object'].get('published', '') if activities else '',
     actor=Defaulter(**actor),
+    rels=rels or {},
     )
 
 

--- a/granary/atom.py
+++ b/granary/atom.py
@@ -45,7 +45,8 @@ def activities_to_atom(activities, actor, title=None, request_url=None,
   # Strip query params from URLs so that we don't include access tokens, etc
   host_url = (_remove_query_params(host_url) if host_url
               else 'https://github.com/snarfed/granary')
-  request_url = _remove_query_params(request_url) if request_url else host_url
+  if request_url is None:
+    request_url = host_url
 
   for a in activities:
     act_type = source.object_type(a)

--- a/granary/templates/user_feed.atom
+++ b/granary/templates/user_feed.atom
@@ -16,9 +16,12 @@
 <updated>{{ updated }}</updated>
 {% include "author.atom" %}
 
-<link href="{{ actor.url }}" rel="alternate" type="text/html" />
+<link rel="alternate" href="{{ actor.url }}" type="text/html" />
 <link rel="avatar" href="{{ actor.image.url }}" />
-<link href="{{ request_url }}" rel="self" type="application/atom+xml" />
+<link rel="self" href="{{ request_url }}" type="application/atom+xml" />
+{% for rel, url in rels.items() %}
+<link rel="{{ rel }}" href="{{ url }}" />
+{% endfor %}
 
 {% for activity in items %}
 <entry>

--- a/granary/test/test_atom.py
+++ b/granary/test/test_atom.py
@@ -130,6 +130,11 @@ article content
 </blockquote>
 """, got)
 
+  def test_rels(self):
+    got = atom.activities_to_atom([], {}, rels={'foo': 'bar', 'baz': 'baj'})
+    self.assert_multiline_in('<link rel="foo" href="bar" />', got)
+    self.assert_multiline_in('<link rel="baz" href="baj" />', got)
+
   def test_xml_base(self):
     self.assert_multiline_in("""
 <?xml version="1.0" encoding="UTF-8"?>
@@ -164,9 +169,9 @@ article content
  <name>My Name</name>
 </author>
 
-<link href="http://my/site" rel="alternate" type="text/html" />
+<link rel="alternate" href="http://my/site" type="text/html" />
 <link rel="avatar" href="http://my/picture" />
-<link href="https://my.site/feed" rel="self" type="application/atom+xml" />
+<link rel="self" href="https://my.site/feed" type="application/atom+xml" />
 
 <entry>
 

--- a/granary/test/test_atom.py
+++ b/granary/test/test_atom.py
@@ -15,17 +15,21 @@ class AtomTest(testutil.HandlerTest):
 
   def test_activities_to_atom(self):
     for test_module in test_facebook, test_instagram, test_twitter:
+      request_url = 'http://request/url?access_token=foo'
+      host_url = 'http://host/url'
+      base_url = 'http://base/url'
       self.assert_multiline_equals(
-        test_module.ATOM % {'request_url': 'http://request/url',
-                            'host_url': 'http://host/url',
-                            'base_url': 'http://base/url',
-                            },
+        test_module.ATOM % {
+          'request_url': request_url,
+          'host_url': host_url,
+          'base_url': base_url,
+        },
         atom.activities_to_atom(
           [copy.deepcopy(test_module.ACTIVITY)],
           test_module.ACTOR,
-          request_url='http://request/url?access_token=foo',
-          host_url='http://host/url',
-          xml_base='http://base/url',
+          request_url=request_url,
+          host_url=host_url,
+          xml_base=base_url
         ))
 
   def test_title(self):

--- a/granary/test/test_facebook.py
+++ b/granary/test/test_facebook.py
@@ -804,9 +804,9 @@ ATOM = """\
  <name>Ryan Barrett</name>
 </author>
 
-<link href="https://snarfed.org" rel="alternate" type="text/html" />
+<link rel="alternate" href="https://snarfed.org" type="text/html" />
 <link rel="avatar" href="https://graph.facebook.com/v2.2/212038/picture?type=large" />
-<link href="%(request_url)s" rel="self" type="application/atom+xml" />
+<link rel="self" href="%(request_url)s" type="application/atom+xml" />
 
 <entry>
 

--- a/granary/test/test_instagram.py
+++ b/granary/test/test_instagram.py
@@ -374,9 +374,9 @@ ATOM = """\
  <name>Ryan B</name>
 </author>
 
-<link href="http://snarfed.org" rel="alternate" type="text/html" />
+<link rel="alternate" href="http://snarfed.org" type="text/html" />
 <link rel="avatar" href="http://picture/ryan" />
-<link href="%(request_url)s" rel="self" type="application/atom+xml" />
+<link rel="self" href="%(request_url)s" type="application/atom+xml" />
 
 <entry>
 

--- a/granary/test/test_twitter.py
+++ b/granary/test/test_twitter.py
@@ -491,9 +491,9 @@ ATOM = """\
  <name>Ryan Barrett</name>
 </author>
 
-<link href="https://snarfed.org/" rel="alternate" type="text/html" />
+<link rel="alternate" href="https://snarfed.org/" type="text/html" />
 <link rel="avatar" href="https://twitter.com/snarfed_org/profile_image?size=original" />
-<link href="%(request_url)s" rel="self" type="application/atom+xml" />
+<link rel="self" href="%(request_url)s" type="application/atom+xml" />
 
 <entry>
 

--- a/test_activitystreams.py
+++ b/test_activitystreams.py
@@ -136,7 +136,7 @@ class HandlerTest(testutil.HandlerTest):
       self.assertEquals(200, resp.status_int)
       self.assert_multiline_equals(
         test_module.ATOM % {
-          'request_url': 'http://localhost/fake',
+          'request_url': 'http://localhost/fake?format=atom&amp;access_token=foo&amp;a=b',
           'host_url': 'http://fa.ke/',
           'base_url': 'http://fa.ke/',
         },

--- a/test_app.py
+++ b/test_app.py
@@ -97,9 +97,9 @@ ATOM_CONTENT = """\
  <name>My Name</name>
 </author>
 
-<link href="http://my/site" rel="alternate" type="text/html" />
+<link rel="alternate" href="http://my/site" type="text/html" />
 <link rel="avatar" href="http://my/picture" />
-<link href="http://localhost/url" rel="self" type="application/atom+xml" />
+<link rel="self" href="http://localhost/url" type="application/atom+xml" />
 
 <entry>
 


### PR DESCRIPTION
hey @voxpelli @kylewm mind taking a look at this? specifically 6f540f7. i've actually deployed it to https://granary-demo.appspot.com/ so you can try it there. e.g.:

```sh
$ curl 'https://granary-demo.appspot.com/url?input=html&output=atom&url=https://snarfed.org/&hub=http://foo/bar'
...
<link rel="alternate" href="https://snarfed.org/" type="text/html" />
<link rel="self" href="https://granary-demo.appspot.com/url?input=html&amp;output=atom&amp;url=https://snarfed.org/&amp;hub=http://foo/bar" type="application/atom+xml" />
<link rel="hub" href="http://foo/bar" />
...
```