### PR TITLE
facebook: drop support for See Original links. #368, #650

### DIFF
--- a/granary/facebook.py
+++ b/granary/facebook.py
@@ -141,9 +141,6 @@ RSVP_ENDPOINTS = {
   'rsvp-maybe': '%s/maybe',
 }
 
-# Values for post.action['name'] that indicate a link back to the original post
-SEE_ORIGINAL_ACTIONS=['see original']
-
 FacebookId = collections.namedtuple('FacebookId', ['user', 'post', 'comment'])
 
 
@@ -1090,13 +1087,6 @@ class Facebook(source.Source):
 
       assert not tags
       obj['content'] = content
-
-    # "See Original" links
-    see_orig_links = filter(
-      None, (act.get('link') for act in post.get('actions',[])
-             if act.get('name', '').lower() in SEE_ORIGINAL_ACTIONS))
-    if see_orig_links:
-      obj.setdefault('upstreamDuplicates', []).extend(see_orig_links)
 
     # is there an attachment? prefer to represent it as a picture (ie image
     # object), but if not, fall back to a link.

--- a/granary/test/test_facebook.py
+++ b/granary/test/test_facebook.py
@@ -342,7 +342,10 @@ COMMENT_OBJS = [  # ActivityStreams
       'url': 'https://www.facebook.com/124561947600007',
     }],
     'to': [{'objectType':'group', 'alias':'@public'}],
-    'upstreamDuplicates': ['http://ald.com/foobar'],
+    # no upstreamDuplicates despite the fact that this comment has a See
+    # Original action, since we don't support that any more.
+    # https://github.com/snarfed/bridgy/issues/368
+    # https://github.com/snarfed/bridgy/issues/650
   },
 ]
 COMMENT_WITH_PHOTO_OBJ = copy.deepcopy(COMMENT_OBJS[0])


### PR DESCRIPTION
they've never been officially supported, and they break Known permalinks (and i think at least one other CMS's) pretty badly. known as already migrated away from them. time to pull the plug!