### PR TITLE
add support for bridgy_omit_link="maybe"

### DIFF
--- a/granary/facebook.py
+++ b/granary/facebook.py
@@ -512,12 +512,13 @@ class Facebook(source.Source):
     rsvps = self.urlopen(API_RSVP % (event_id, user_id), _as=list)
     return self.rsvp_to_object(rsvps[0], event={'id': event_id}) if rsvps else None
 
-  def create(self, obj, include_link=False, ignore_formatting=False):
+  def create(self, obj, include_link=source.OMIT_LINK,
+             ignore_formatting=False):
     """Creates a new post, comment, like, or RSVP.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
       ignore_formatting: boolean
 
     Returns:
@@ -539,12 +540,13 @@ class Facebook(source.Source):
     url = API_ALBUMS % (user_id if user_id is not None else 'me')
     return [self.album_to_object(a) for a in self.urlopen(url, _as=list)]
 
-  def preview_create(self, obj, include_link=False, ignore_formatting=False):
+  def preview_create(self, obj, include_link=source.OMIT_LINK,
+                     ignore_formatting=False):
     """Previews creating a new post, comment, like, or RSVP.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
       ignore_formatting: boolean
 
     Returns:
@@ -554,7 +556,8 @@ class Facebook(source.Source):
     return self._create(obj, preview=True, include_link=include_link,
                         ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, preview=None, include_link=False, ignore_formatting=False):
+  def _create(self, obj, preview=None, include_link=source.OMIT_LINK,
+              ignore_formatting=False):
     """Creates a new post, comment, like, or RSVP.
 
     https://developers.facebook.com/docs/graph-api/reference/user/feed#publish
@@ -565,7 +568,8 @@ class Facebook(source.Source):
     Args:
       obj: ActivityStreams object
       preview: boolean
-      include_link: boolean
+      include_link: string
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult
@@ -607,7 +611,7 @@ class Facebook(source.Source):
     people = self._get_person_tags(obj)
 
     url = obj.get('url')
-    if include_link and url:
+    if include_link == source.INCLUDE_LINK and url:
       content += '\n\n(Originally published at: %s)' % url
     preview_content = util.linkify(content)
     if video_url:

--- a/granary/flickr.py
+++ b/granary/flickr.py
@@ -76,12 +76,13 @@ class Flickr(source.Source):
     return flickr_auth.upload(
       params, file, self.access_token_key, self.access_token_secret)
 
-  def create(self, obj, include_link=False, ignore_formatting=False):
+  def create(self, obj, include_link=source.OMIT_LINK,
+             ignore_formatting=False):
     """Creates a photo, comment, or favorite.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
       ignore_formatting: boolean
 
     Returns:
@@ -93,12 +94,14 @@ class Flickr(source.Source):
     return self._create(obj, preview=False, include_link=include_link,
                         ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False, ignore_formatting=False):
+  def preview_create(self, obj, include_link=source.OMIT_LINK,
+                     ignore_formatting=False):
     """Preview creation of a photo, comment, or favorite.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
+      ignore_formatting: boolean
 
     Returns:
       a CreationResult whose description will be an HTML summary of
@@ -108,7 +111,8 @@ class Flickr(source.Source):
     return self._create(obj, preview=True, include_link=include_link,
                         ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, preview, include_link=False, ignore_formatting=False):
+  def _create(self, obj, preview, include_link=source.OMIT_LINK,
+              ignore_formatting=False):
     """Creates or previews creating for the previous two methods.
 
     https://www.flickr.com/services/api/upload.api.html
@@ -119,7 +123,8 @@ class Flickr(source.Source):
     Args:
       obj: ActivityStreams object
       preview: boolean
-      include_link: boolean
+      include_link: string
+      ignore_formatting: boolean
 
     Return:
       a CreationResult
@@ -149,7 +154,7 @@ class Flickr(source.Source):
         content = None
 
       # add original post link
-      if include_link:
+      if include_link == source.INCLUDE_LINK:
         content = ((content + '\n\n') if content else '') + link_text
 
       if preview:
@@ -228,7 +233,7 @@ class Flickr(source.Source):
           'link to a Flickr photo or to an original post that publishes a '
           '<a href="http://indiewebcamp.com/rel-syndication">rel-syndication</a> link to Flickr.')
 
-      if include_link:
+      if include_link == source.INCLUDE_LINK:
         content += '\n\n' + link_text
       if preview:
         return source.creation_result(

--- a/granary/instagram.py
+++ b/granary/instagram.py
@@ -306,12 +306,13 @@ class Instagram(source.Source):
     """
     return None
 
-  def create(self, obj, include_link=False, ignore_formatting=False):
+  def create(self, obj, include_link=source.OMIT_LINK,
+             ignore_formatting=False):
     """Creates a new comment or like.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
       ignore_formatting: boolean
 
     Returns: a CreationResult. if successful, content will have and 'id' and
@@ -320,12 +321,14 @@ class Instagram(source.Source):
     return self._create(obj, include_link=include_link, preview=False,
                         ignore_formatting=ignore_formatting)
 
-  def preview_create(self, obj, include_link=False, ignore_formatting=False):
+  def preview_create(self, obj, include_link=source.OMIT_LINK,
+                     ignore_formatting=False):
     """Preview a new comment or like.
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
+      ignore_formatting: boolean
 
     Returns: a CreationResult. if successful, content and description
              will describe the new instagram object.
@@ -333,7 +336,8 @@ class Instagram(source.Source):
     return self._create(obj, include_link=include_link, preview=True,
                         ignore_formatting=ignore_formatting)
 
-  def _create(self, obj, include_link=False, preview=None, ignore_formatting=False):
+  def _create(self, obj, include_link=source.OMIT_LINK, preview=None,
+              ignore_formatting=False):
     """Creates a new comment or like.
 
     The OAuth access token must have been created with scope=comments+likes (or
@@ -348,7 +352,7 @@ class Instagram(source.Source):
 
     Args:
       obj: ActivityStreams object
-      include_link: boolean
+      include_link: string
       preview: boolean
 
     Returns: a CreationResult. if successful, content will have and 'id' and

--- a/granary/source.py
+++ b/granary/source.py
@@ -33,6 +33,11 @@ FRIENDS = '@friends'
 APP = '@app'
 SEARCH = '@search'
 
+# values for create's include_link param
+OMIT_LINK = 'omit'
+INCLUDE_LINK = 'include'
+INCLUDE_IF_TRUNCATED = 'if truncated'
+
 RSVP_TO_EVENT = {
   'rsvp-yes': 'attending',
   'rsvp-no': 'notAttending',
@@ -239,7 +244,7 @@ class Source(object):
             'updatedSince': False,
             }
 
-  def create(self, obj, include_link=False, ignore_formatting=False):
+  def create(self, obj, include_link=OMIT_LINK, ignore_formatting=False):
     """Creates a new object: a post, comment, like, share, or RSVP.
 
     Subclasses should override this. Different sites will support different
@@ -249,8 +254,8 @@ class Source(object):
     Args:
       obj: ActivityStreams object. At minimum, must have the content field.
         objectType is strongly recommended.
-      include_link: boolean. If True, includes a link to the object
-        (if it has one) in the content.
+      include_link: string. 'include', 'omit', or 'if truncated'; whether to
+        include a link to the object (if it has one) in the content.
       ignore_formatting: whether to use content text as is, instead of
         converting its HTML to plain text styling (newlines, etc.)
 
@@ -263,7 +268,7 @@ class Source(object):
     """
     raise NotImplementedError()
 
-  def preview_create(self, obj, include_link=False, ignore_formatting=False):
+  def preview_create(self, obj, include_link=OMIT_LINK, ignore_formatting=False):
     """Previews creating a new object: a post, comment, like, share, or RSVP.
 
     Returns HTML that previews what create() with the same object will do.
@@ -275,7 +280,7 @@ class Source(object):
     Args:
       obj: ActivityStreams object. At minimum, must have the content field.
         objectType is strongly recommended.
-      include_link: boolean. If True, includes a link to the object
+      include_link: string. Whether to include a link to the object
         (if it has one) in the content.
       ignore_formatting: whether to use content text as is, instead of
         converting its HTML to plain text styling (newlines, etc.)

--- a/granary/test/test_facebook.py
+++ b/granary/test/test_facebook.py
@@ -2002,8 +2002,8 @@ http://b http://c""",
         'displayName': 'my content',
         'url': 'http://obj.co',
         })
-    self.fb.create(obj, include_link=True)
-    preview = self.fb.preview_create(obj, include_link=True)
+    self.fb.create(obj, include_link=source.INCLUDE_LINK)
+    preview = self.fb.preview_create(obj, include_link=source.INCLUDE_LINK)
     self.assertEquals(
       'my content\n\n(Originally published at: <a href="http://obj.co">http://obj.co</a>)',
       preview.content)
@@ -2024,8 +2024,8 @@ http://b http://c""",
         'displayName': 'my title',
         'url': 'http://obj.co',
         })
-    self.fb.create(obj, include_link=True)
-    preview = self.fb.preview_create(obj, include_link=True)
+    self.fb.create(obj, include_link=source.INCLUDE_LINK)
+    preview = self.fb.preview_create(obj, include_link=source.INCLUDE_LINK)
     self.assertEquals(
       'my title\n\nmy content\n\n(Originally published at: <a href="http://obj.co">http://obj.co</a>)',
       preview.content)
@@ -2046,8 +2046,8 @@ http://b http://c""",
         'displayName': 'my\ncontent',
         'url': 'http://obj.co',
         })
-    self.fb.create(obj, include_link=True)
-    preview = self.fb.preview_create(obj, include_link=True)
+    self.fb.create(obj, include_link=source.INCLUDE_LINK)
+    preview = self.fb.preview_create(obj, include_link=source.INCLUDE_LINK)
     self.assertEquals(
       'my\ncontent\n\n(Originally published at: <a href="http://obj.co">http://obj.co</a>)',
       preview.content)

--- a/granary/test/test_flickr.py
+++ b/granary/test/test_flickr.py
@@ -837,7 +837,8 @@ class FlickrTest(testutil.TestCase):
   def test_preview_create_photo(self):
     self._expect_lookup_users()
     self.mox.ReplayAll()
-    preview = self.flickr.preview_create(OBJECT, include_link=True)
+    preview = self.flickr.preview_create(
+      OBJECT, include_link=source.INCLUDE_LINK)
     self.assertEquals('post', preview.description)
     self.assertIn('Photo #164', preview.content)
     self.assertIn(
@@ -918,7 +919,7 @@ class FlickrTest(testutil.TestCase):
       'id': '9876',
       'url': 'https://www.flickr.com/photos/kindofblue115/9876/',
       'type': 'post',
-    }, self.flickr.create(OBJECT, include_link=True).content)
+    }, self.flickr.create(OBJECT, include_link=source.INCLUDE_LINK).content)
 
   def test_create_photo_failure(self):
     """If uploading returns a failure, interpret it correctly.
@@ -1006,7 +1007,8 @@ class FlickrTest(testutil.TestCase):
     self.assertNotIn('should hide', preview)
 
   def test_preview_create_comment(self):
-    preview = self.flickr.preview_create(REPLY_OBJ, include_link=True)
+    preview = self.flickr.preview_create(
+      REPLY_OBJ, include_link=source.INCLUDE_LINK)
     self.assertEquals(
       'comment on <a href="https://www.flickr.com/photos/marietta_wood_works/'
       '21904325000/in/contacts/">this photo</a>.',
@@ -1038,7 +1040,8 @@ class FlickrTest(testutil.TestCase):
 
     self.mox.ReplayAll()
 
-    reply_content = self.flickr.create(REPLY_OBJ, include_link=True).content
+    reply_content = self.flickr.create(
+      REPLY_OBJ, include_link=source.INCLUDE_LINK).content
     self.assertEquals(
       '4942564-21904325000-72157661220102352',
       reply_content.get('id'))


### PR DESCRIPTION
when this value is "maybe", include a link iff the content of the
post must be truncated, e.g. when posting to Twitter.

this is the default behavior of the brevity library -- permalinks
are automatically omitted if the tweet is <= 140 characters.

ref snarfed/bridgy#561