### PR TITLE
fix test regressions caused by changes to mf2util.find_author 

### DIFF
--- a/granary/test/test_atom.py
+++ b/granary/test/test_atom.py
@@ -210,12 +210,12 @@ my content
 
 </feed>
 """, atom.html_to_atom("""\
+<div class="h-feed">
 <div class="p-author h-card">
   <a href="http://my/site">My Name</a>
   <img src="http://my/picture" />
 </div>
 
-<div class="h-feed">
 <span class="p-name">my title</span>
 
 <article class="h-entry">

--- a/granary/test/test_microformats2.py
+++ b/granary/test/test_microformats2.py
@@ -510,10 +510,11 @@ foo
     'url': 'http://li/nk',
     'image': {'url': 'http://pic/ture'},
   }, microformats2.find_author(mf2py.parse(doc="""\
-<body class="p-author h-card">
+<body class="h-entry">
+<div class="p-author h-card">
 <a href="http://li/nk">my name</a>
 <img class="u-photo" src="http://pic/ture" />
-<div class="h-entry"></div>
+</div>
 </body>
 """, url='http://123')))
 


### PR DESCRIPTION
- mf2util changed to follow /authorship more closely, breaking some assumptions
  in our unittests
- Move p-author h-card inside of an h-entry or h-feed so that it is picked up
  by the authorship algorithm