### PR TITLE
upgrade brevity and add test to verify new behavior

### DIFF
--- a/granary/test/test_twitter.py
+++ b/granary/test/test_twitter.py
@@ -1390,6 +1390,14 @@ class TwitterTest(testutil.TestCase):
       'note', False)
     self.assertEquals(expected, result)
 
+    orig = (u'Leaving this here for future reference. Turn on debug menu '
+      u'in Mac App Store `defaults write com.apple.appstore ShowDebugMenu '
+      u'-bool true`')
+    expected = (u'Leaving this here for future reference. Turn on debug menu '
+      u'in Mac App Store `defaults write com.apple.appstore ShowDebugMenu…')
+    result = self.twitter._truncate(orig, 'http://foo.com', source.OMIT_LINK, 'note', False)
+    self.assertEquals(expected, result)
+
     twitter.MAX_TWEET_LENGTH = 20
     twitter.TCO_LENGTH = 5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ mf2util>=0.3.3
 oauth-dropins>=1.5
 requests>=2.10.0
 requests-toolbelt>=0.6.2
-brevity>=0.2.8
+brevity>=0.2.10
 urllib3>=1.14


### PR DESCRIPTION
it now recognizes com.apple as a URL in the string com.apple.appstore
like Twitter does