### PR TITLE
bump version of brevity dependency to get new TLDs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ mf2util>=0.5.0
 oauth-dropins>=1.6
 requests>=2.10.0
 requests-toolbelt>=0.6.2
-brevity>=0.2.11
+brevity>=0.2.12
 urllib3>=1.14


### PR DESCRIPTION
should fix https://github.com/snarfed/bridgy/issues/714