### PR TITLE
add facebook pride reacji

### DIFF
--- a/granary/facebook.py
+++ b/granary/facebook.py
@@ -185,6 +185,7 @@ REACTION_CONTENT = {
   'SAD': u'😢',
   'ANGRY': u'😡',
   'THANKFUL': u'🌼',  # https://github.com/snarfed/bridgy/issues/748
+  'PRIDE': u'🏳️‍🌈',
   # nothing for LIKE (it's a like :P) or for NONE
 }
 

--- a/granary/test/test_facebook.py
+++ b/granary/test/test_facebook.py
@@ -221,7 +221,7 @@ POST = {  # Facebook
     {'id': '683713', 'name': 'Bob Y'},
   ]},
   'reactions': {'data': [
-    # possible types are NONE, LIKE, LOVE, WOW, HAHA, SAD, ANGRY, THANKFUL
+    # possible types are NONE, LIKE, LOVE, WOW, HAHA, SAD, ANGRY, THANKFUL, PRIDE
     {'id': '100005', 'name': 'Laugher', 'type': 'HAHA'},
     {'id': '100006', 'name': 'Cryer', 'type': 'SAD'},
     # likes are duplicated in reactions


### PR DESCRIPTION
They did it again: new reacji on Facebook. The announcement can be found [here](https://newsroom.fb.com/news/2017/06/facebook-celebrates-pride-month/), and it's not only temporary, it's also based on location. I can't post them myself at the moment, and I haven't received one, but here's an example that has them: https://www.facebook.com/Israel.Gay.Tourists.Information/videos/634064940125826/
(via https://twitter.com/raymonmens/status/873434818016681985)


I based this on your commit to add Thankful (https://github.com/snarfed/granary/commit/5b53c3cf43e046ca29e1423072af96216ba412bc)

The Facebook-docs link you added there is now indeed updated with `PRIDE`.
https://developers.facebook.com/docs/graph-api/reference/post/reactions


I hope the 🏳️‍🌈 (rainbow flag) is ok, since it's an addition of Apple (right?). The Github interface in which I'm writing this PR is already acting strange. 🌈 (rainbow) might be a good alternative.