### PR TITLE
Render JSON Feed entries’ content with render_content

### DIFF
--- a/granary/test/test_jsonfeed.py
+++ b/granary/test/test_jsonfeed.py
@@ -57,7 +57,7 @@ class JsonFeedTest(testutil.TestCase):
 
   def test_activities_to_jsonfeed_image_attachment(self):
       self.assert_equals([{
-        'content_text': '',
+        'content_html': '\n<p>\n<img class="u-photo" src="http://pict/ure.jpg" alt="" />\n</p>',
         'attachments': [{
           'url': 'http://pict/ure.jpg',
           'mime_type': 'image/jpeg',
@@ -67,7 +67,9 @@ class JsonFeedTest(testutil.TestCase):
       }], {})['items'])
 
   def test_activities_to_jsonfeed_ignore_other_attachment_types(self):
-      self.assert_equals([{'content_text': ''}], activities_to_jsonfeed([{
+      self.assert_equals([{
+        'content_html': '\n<p>\n<a class="link" href="http://some/one">\n</a>\n</p>'
+      }], activities_to_jsonfeed([{
         'attachments': [{
           'url': 'http://quoted/tweet',
           'objectType': 'note',

--- a/granary/test/testdata/article_with_attachment_image_list.feed-from-as.json
+++ b/granary/test/testdata/article_with_attachment_image_list.feed-from-as.json
@@ -8,7 +8,7 @@
     "avatar": "http://example.com/martin/image"
   },
   "items": [{
-    "content_text": "",
+    "content_html": "\n<p>\n</p>",
     "attachments": [{
       "mime_type": "image/gif",
       "url": "http://a/pic.gif"

--- a/granary/test/testdata/article_with_attachment_stream_list.feed-from-as.json
+++ b/granary/test/testdata/article_with_attachment_stream_list.feed-from-as.json
@@ -8,7 +8,7 @@
     "avatar": "http://example.com/martin/image"
   },
   "items": [{
-    "content_text": "",
+    "content_html": "\n<p>\n</p>",
     "attachments": [{
       "mime_type": "video/quicktime",
       "url": "http://a/vidjo.mov"

--- a/granary/test/testdata/article_with_audio_video.feed-from-as.json
+++ b/granary/test/testdata/article_with_audio_video.feed-from-as.json
@@ -9,7 +9,7 @@
   },
   "items": [{
     "title": "i'm ready to speak",
-    "content_html": "something",
+    "content_html": "something\n<p><audio class=\"u-audio\" src=\"http://a/podcast.mp3\" controls=\"controls\">Your browser does not support the audio tag. <a href=\"http://a/podcast.mp3\">Click here to listen directly.</a></audio>\n</p>\n<p><video class=\"u-video\" src=\"http://a/vidjo.mov\" controls=\"controls\" poster=\"\">Your browser does not support the video tag. <a href=\"http://a/vidjo.mov\">Click here to view directly. </a></video>\n</p>",
     "attachments": [{
       "mime_type": "audio/mpeg",
       "url": "http://a/podcast.mp3"

--- a/granary/test/testdata/note.feed-from-as.json
+++ b/granary/test/testdata/note.feed-from-as.json
@@ -12,7 +12,7 @@
     "url": "http://example.com/blog-post-123",
     "image": "http://example.com/blog-post-123/image",
     "summary": "too cool to summarize",
-    "content_html": "A note. link too<p><img src=\"http://example.com/blog-post-123/image\"/></p>",
+    "content_html": "A note. <a href=\"http://my/link\">link</a> too\n<p>  <span class=\"p-location h-card\">\n    <data class=\"p-uid\" value=\"31cb9e7ed29dbe52\"></data>\n    <a class=\"p-name u-url\" href=\"https://maps.google.com/maps?q=32.4004416,-98.9852672\">Carcassonne, Aude</a>\n    \n    \n  </span>\n</p>",
     "date_published": "2012-02-22T20:26:41",
     "date_modified": "2013-10-25T10:31:30+00:00",
     "author": {


### PR DESCRIPTION
See #148.

This isn’t ready yet; I’m only opening a PR so that I can see the CI output.