### PR TITLE
Gitignore compiled Python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ instagram_sessionid_cookie
 linkedin_client_*
 twitter_app_*
 TAGS
+*.pyc


### PR DESCRIPTION
To remove noise from diffs / `git status` as well as removing the risk
of accidentally committing these files, we should add this to our
`.gitignore`.