### PR TITLE
Add RSVP library support for Meetup.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ instagram_client_*
 instagram_scrape_base
 instagram_sessionid_cookie
 linkedin_client_*
+meetup_client_*
 twitter_app_*
 TAGS
 *.pyc

--- a/api.py
+++ b/api.py
@@ -43,6 +43,7 @@ from granary import (
   jsonfeed,
   mastodon,
   microformats2,
+  meetup,
   rss,
   source,
   twitter,
@@ -132,6 +133,10 @@ class Handler(handlers.ModernHandler):
         instance=util.get_required_param(self, 'instance'),
         access_token=util.get_required_param(self, 'access_token'),
         user_id=util.get_required_param(self, 'user_id'))
+    elif site == 'meetup':
+      src = meetup.Meetup(
+        access_token_key=util.get_required_param(self, 'access_token_key'),
+        access_token_secret=util.get_required_param(self, 'access_token_secret'))
     else:
       src_cls = source.sources.get(site)
       if not src_cls:

--- a/app.py
+++ b/app.py
@@ -37,6 +37,7 @@ from granary.facebook import Facebook
 from granary.flickr import Flickr
 from granary.github import GitHub
 from granary.mastodon import Mastodon
+from granary.meetup import Meetup
 from granary.instagram import Instagram
 from granary.twitter import Twitter
 
@@ -57,6 +58,7 @@ SILOS = (
   'github',
   'instagram',
   'mastodon',
+  'meetup',
   'twitter',
 )
 OAUTHS = {  # maps oauth-dropins module name to module
@@ -68,6 +70,7 @@ SILO_DOMAINS = {cls.DOMAIN for cls in (
   Flickr,
   GitHub,
   Instagram,
+  Meetup,
   Twitter,
 )}
 SCOPE_OVERRIDES = {
@@ -77,6 +80,8 @@ SCOPE_OVERRIDES = {
   'github': 'notifications,public_repo',
   # https://docs.joinmastodon.org/api/permissions/
   'mastodon': 'read',
+  # https://www.meetup.com/meetup_api/auth/#oauth2-scopes
+  'meetup': 'rsvp'
 }
 
 

--- a/granary/meetup.py
+++ b/granary/meetup.py
@@ -1,0 +1,101 @@
+# coding=utf-8
+"""Meetup.com source class.
+"""
+
+from . import source
+import logging
+from oauth_dropins import meetup
+from oauth_dropins.webutil import util
+import re
+import urllib.parse, urllib.request
+
+API_BASE = 'https://api.meetup.com'
+API_RSVPS = '/%(urlname)s/events/%(event_id)s/rsvps'
+
+# We don't want to be too strict here with what a valid urlname and event_id
+# are because Meetup.com haven't documented it too well, and it may change
+EVENT_URL_RE = re.compile(r'https://(www\.|)meetup.com/([^/]+)/events/([0-9]+)/?$')
+
+class Meetup(source.Source):
+
+    DOMAIN = 'meetup.com'
+    NAME = 'Meetup.com'
+
+    URL_CANONICALIZER = util.UrlCanonicalizer(
+            domain=DOMAIN,
+            approve=EVENT_URL_RE)
+
+    def __init__(self, access_token):
+        self.access_token = access_token
+        pass
+
+    def create(self, obj, include_link=source.OMIT_LINK, ignore_formatting=False):
+        return self._create(obj, False, include_link, ignore_formatting)
+
+    def preview_create(self, obj, include_link=source.OMIT_LINK, ignore_formatting=False):
+        return self._create(obj, True, include_link, ignore_formatting)
+
+    def post_rsvp(self, urlname, event_id, response):
+        url = API_BASE + API_RSVPS % {
+                'urlname': urlname,
+                'event_id': event_id,
+                }
+        params = 'response=%(response)s' % {
+                'response': response,
+                }
+        logging.debug('Creating RSVP=%(rsvp)s for %(urlname)s %(event_id)s' % {
+            'rsvp': response,
+            'urlname': urlname,
+            'event_id': event_id,
+            })
+        return meetup.urlopen_bearer_token(url, self.access_token, data=params)
+
+    def _create(self, obj, preview=False, include_link=source.OMIT_LINK, ignore_formatting=False):
+        if not preview in (False, True):
+            return self.return_error('Invalid Preview parameter, must be True or False')
+        verb = obj.get('verb')
+        response = None
+        if verb == 'rsvp-yes':
+            response = 'yes'
+        elif verb == 'rsvp-no':
+            response = 'no'
+        elif verb == 'rsvp-maybe' or verb == 'rsvp-interested':
+            return self.return_error('Meetup.com does not support %(verb)s' % {'verb': verb})
+        else:
+            return self.return_error('Meetup.com syndication does not support %(verb)s' % {'verb': verb})
+
+        event_url = obj.get('inReplyTo')
+        if not event_url:
+            return self.return_error('missing an in-reply-to')
+
+        event_url = self.URL_CANONICALIZER(event_url)
+        if not event_url:
+            return self.return_error('Invalid Meetup.com event URL')
+
+        parsed_url_part = EVENT_URL_RE.match(event_url)
+        if not parsed_url_part:
+            return self.return_error('Invalid Meetup.com event URL')
+
+        urlname = parsed_url_part.group(2)
+        event_id = parsed_url_part.group(3)
+
+        if preview:
+            desc = ('<span class="verb">RSVP %s</span> to <a href="%s">this event</a>.' %
+                    (verb[5:], event_url))
+            return source.creation_result(description=desc)
+
+        create_resp = {
+                'url': '%(event_url)s#rsvp-by-%(user_id)s' % {
+                    'event_url': event_url,
+                    'user_id': obj['actor']['numeric_id'],
+                    },
+                'type': 'rsvp'
+                }
+
+        resp = self.post_rsvp(urlname, event_id, response)
+        logging.debug('Response: %s %s', resp.getcode(), resp.read())
+
+        return source.creation_result(create_resp)
+
+    def return_error(self, msg):
+        return source.creation_result(abort=True, error_plain=msg, error_html=msg)

--- a/granary/templates/index.html
+++ b/granary/templates/index.html
@@ -135,6 +135,13 @@ Want social feeds in your feed reader? Use <a href="https://twitter-atom.appspot
 </div>
 </div>
 
+<div class="row">
+<div class="col-lg-2 col-sm-4 col-xs-6">
+  <img src="/oauth_dropins/static/meetup_2x.png" height="50" class="shadow"
+       title="Meetup is only supported in the library, not in the REST API or demo site here.">
+</div>
+</div>
+
 <!--
   -- interactive form
   -->

--- a/granary/tests/test_meetup.py
+++ b/granary/tests/test_meetup.py
@@ -1,0 +1,168 @@
+from oauth_dropins.webutil import testutil
+from oauth_dropins.webutil import util
+
+from granary.meetup import Meetup
+
+import copy
+import json
+
+# test data
+def tag_uri(name):
+    return util.tag_uri('meetup.com', name)
+
+RSVP_ACTIVITY = {
+        'id': tag_uri('145304994_rsvp_11500'),
+        'objectType': 'activity',
+        'verb': 'rsvp-yes',
+        'inReplyTo': 'https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439',
+        'actor': {
+            'objectType': 'person',
+            'displayName': 'Jamie T',
+            'id': tag_uri('189380737'),
+            'numeric_id': '189380737',
+            'url': 'https://www.meetup.com/members/189380737/',
+            'image': {'url': 'https://secure.meetupstatic.com/photos/member/6/8/7/5/member_288326741.jpeg'},
+            },
+        }
+
+class MeetupTest(testutil.TestCase):
+
+    def setUp(self):
+        super(MeetupTest, self).setUp()
+        self.meetup = Meetup('token-here')
+
+    def test_create_rsvp_yes(self):
+        self.expect_urlopen(
+                url='https://api.meetup.com/PHPMiNDS-in-Nottingham/events/264008439/rsvps',
+                data='response=yes',
+                response=200,
+                headers={
+                    'Authorization': 'Bearer token-here'
+                    }
+                )
+        self.mox.ReplayAll()
+
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-yes'
+        created = self.meetup.create(rsvp)
+        self.assert_equals({'url': 'https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439#rsvp-by-189380737', 'type': 'rsvp'},
+                created.content,
+                '%s\n%s' % (created.content, rsvp))
+
+    def test_create_rsvp_yes_with_www(self):
+        self.expect_urlopen(
+                url='https://api.meetup.com/PHPMiNDS-in-Nottingham/events/264008439/rsvps',
+                data='response=yes',
+                response=200,
+                headers={
+                    'Authorization': 'Bearer token-here'
+                    }
+                )
+        self.mox.ReplayAll()
+
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['inReplyTo'] = 'https://www.meetup.com/PHPMiNDS-in-Nottingham/events/264008439'
+        rsvp['verb'] = 'rsvp-yes'
+        created = self.meetup.create(rsvp)
+        self.assert_equals({'url': 'https://www.meetup.com/PHPMiNDS-in-Nottingham/events/264008439#rsvp-by-189380737', 'type': 'rsvp'},
+                created.content,
+                '%s\n%s' % (created.content, rsvp))
+
+    def test_preview_create_rsvp_yes(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-yes'
+        preview = self.meetup.preview_create(rsvp)
+        self.assertEqual('<span class="verb">RSVP yes</span> to '
+                          '<a href="https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439">this event</a>.',
+                          preview.description)
+
+    def test__create_rsvp_invalid_preview_parameter(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-yes'
+        result = self.meetup._create(rsvp, preview=None)
+        self.assertTrue(result.abort)
+        self.assertIn('Invalid Preview parameter, must be True or False', result.error_plain)
+        self.assertIn('Invalid Preview parameter, must be True or False', result.error_html)
+
+    def test_create_rsvp_no(self):
+        self.expect_urlopen(
+                url='https://api.meetup.com/PHPMiNDS-in-Nottingham/events/264008439/rsvps',
+                data='response=no',
+                response=200,
+                headers={
+                    'Authorization': 'Bearer token-here'
+                    }
+                )
+        self.mox.ReplayAll()
+
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-no'
+        created = self.meetup.create(rsvp)
+
+        self.assert_equals({'url': 'https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439#rsvp-by-189380737', 'type': 'rsvp'},
+                created.content,
+                '%s\n%s' % (created.content, rsvp))
+
+    def test_create_rsvp_handles_url_with_trailing_slash(self):
+        self.expect_urlopen(
+                url='https://api.meetup.com/PHPMiNDS-in-Nottingham/events/264008439/rsvps',
+                data='response=yes',
+                response=200,
+                headers={
+                    'Authorization': 'Bearer token-here'
+                    }
+                )
+        self.mox.ReplayAll()
+
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['inReplyTo'] = 'https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439/'
+        created = self.meetup.create(rsvp)
+        self.assert_equals({'url': 'https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439/#rsvp-by-189380737', 'type': 'rsvp'},
+                created.content,
+                '%s\n%s' % (created.content, rsvp))
+
+    def test_create_rsvp_does_not_support_rsvp_interested(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-interested'
+        result = self.meetup.create(rsvp)
+
+        self.assertTrue(result.abort)
+        self.assertIn('Meetup.com does not support rsvp-interested', result.error_plain)
+        self.assertIn('Meetup.com does not support rsvp-interested', result.error_html)
+
+    def test_create_rsvp_does_not_support_rsvp_maybe(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'rsvp-maybe'
+        result = self.meetup.create(rsvp)
+
+        self.assertTrue(result.abort)
+        self.assertIn('Meetup.com does not support rsvp-maybe', result.error_plain)
+        self.assertIn('Meetup.com does not support rsvp-maybe', result.error_html)
+
+    def test_create_rsvp_does_not_support_other_verbs(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['verb'] = 'post'
+        result = self.meetup.create(rsvp)
+
+        self.assertTrue(result.abort)
+        self.assertIn('Meetup.com syndication does not support post', result.error_plain)
+        self.assertIn('Meetup.com syndication does not support post', result.error_html)
+
+    def test_create_rsvp_without_in_reply_to(self):
+        rsvp = copy.deepcopy(RSVP_ACTIVITY)
+        rsvp['inReplyTo'] = None
+        result = self.meetup.create(rsvp)
+
+        self.assertTrue(result.abort)
+        self.assertIn('missing an in-reply-to', result.error_plain)
+        self.assertIn('missing an in-reply-to', result.error_html)
+
+    def test_create_rsvp_with_invalid_url(self):
+        for url in ['https://meetup.com/PHPMiNDS-in-Nottingham/', 'https://meetup.com/PHPMiNDS-in-Nottingham/events', 'https://meetup.com/PHPMiNDS-in-Nottingham/events/', 'https://meetup.com//events/264008439', 'https://www.eventbrite.com/e/indiewebcamp-amsterdam-tickets-68004881431/faked']:
+            rsvp = copy.deepcopy(RSVP_ACTIVITY)
+            rsvp['inReplyTo'] = url
+            result = self.meetup.create(rsvp)
+
+            self.assertTrue(result.abort)
+            self.assertIn('Invalid Meetup.com event URL', result.error_plain)
+            self.assertIn('Invalid Meetup.com event URL', result.error_html)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(name='granary',
           'Programming Language :: Python :: 3.7',
           'Topic :: Software Development :: Libraries :: Python Modules',
       ],
-      keywords='social facebook flickr github instagram twitter activitystreams html microformats2 mf2 atom rss jsonfeed',
+      keywords='social facebook flickr github instagram twitter activitystreams html microformats2 meetup mf2 atom rss jsonfeed',
       install_requires=[
           'beautifulsoup4~=4.8',
           'brevity>=0.2.17',


### PR DESCRIPTION
As part of snarfed/bridgy/issues/873 we want to add Meetup.com support
to Brid.gy.

Before we can do this, we need to onboard it to granary.

For now, all were adding is RSVP support, so we can't add that in the
Granary webapp, just the library.

Unfortunately we don't get a permalink / ID back from the RSVP endpoint,
so similar to the way that Granary's Facebook likes work, we create our
own "permalink".
