### PR TITLE
Add `embed_post` for embedding the RSVP as HTML

### DIFF
--- a/granary/meetup.py
+++ b/granary/meetup.py
@@ -26,6 +26,21 @@ class Meetup(source.Source):
             domain=DOMAIN,
             approve=EVENT_URL_RE)
 
+    @classmethod
+    def embed_post(cls, obj):
+        """Returns the HTML string for embedding an RSVP from Meetup.com.
+
+        Args:
+          obj:
+          obj: AS1 dict with at least url, and optionally also content.
+
+        Returns: string, HTML
+        """
+        return '<span class="verb">RSVP %s</span> to <a href="%s">this event</a>.' % (
+                source.object_type(obj)[5:],
+                source.Source.base_object(cls, obj)['url']
+                )
+
     def __init__(self, access_token):
         self.access_token = access_token
         pass
@@ -88,9 +103,7 @@ class Meetup(source.Source):
         event_id = parsed_url_part.group(3)
 
         if preview:
-            desc = ('<span class="verb">RSVP %s</span> to <a href="%s">this event</a>.' %
-                    (verb[5:], event_url))
-            return source.creation_result(description=desc)
+            return source.creation_result(description=Meetup.embed_post(obj))
 
         create_resp = {
                 'url': '%(event_url)s#rsvp-by-%(url)s' % {

--- a/granary/tests/test_meetup.py
+++ b/granary/tests/test_meetup.py
@@ -296,3 +296,6 @@ class MeetupTest(testutil.TestCase):
 
     def test_user_url(self):
         self.assert_equals('https://www.meetup.com/members/1234/', self.meetup.user_url(1234))
+
+    def test_embed_post(self):
+        self.assert_equals('<span class="verb">RSVP yes</span> to <a href="https://meetup.com/PHPMiNDS-in-Nottingham/events/264008439">this event</a>.', Meetup.embed_post(RSVP_ACTIVITY))


### PR DESCRIPTION
As noted in snarfed/bridgy#906, this is required to better display the
RSVPs in the Bridgy publish UI.