### PR TITLE
Fix: Handle `null` photos from the Meetup API

### DIFF
--- a/granary/meetup.py
+++ b/granary/meetup.py
@@ -121,10 +121,11 @@ class Meetup(source.Source):
       user_id_str = str(user_id)
       published_s = round(user.get('joined') / 1000)
       published_dt = datetime.datetime.utcfromtimestamp(published_s)
+      photo = user.get('photo', {}).get('photo_link', 'https://secure.meetupstatic.com/img/noPhoto_80.png')
       return util.trim_nulls({
         'objectType': 'person',
         'displayName': user.get('name'),
-        'image': {'url': user.get('photo', {}).get('photo_link')},
+        'image': {'url': photo},
         'id': self.tag_uri(user_id_str),
         # numeric_id is our own custom field that always has the source's numeric
         # user id, if available.

--- a/granary/tests/test_meetup.py
+++ b/granary/tests/test_meetup.py
@@ -260,5 +260,39 @@ class MeetupTest(testutil.TestCase):
     def test_user_to_actor(self):
         self.assert_equals(ACTOR, self.meetup.user_to_actor(USER_JSON))
 
+    def test_user_to_actor_with_no_photo(self):
+        user_json = {
+                "id": 189380737,
+                "name": "Jamie Tanna",
+                "email": "email@example.com",
+                "status": "active",
+                "joined": 1435825101000,
+                "city": "Nottingham",
+                "country": "gb",
+                "localized_country_name": "United Kingdom",
+                "state": "J9",
+                "lat": 52.95,
+                "lon": -1.18,
+                "is_pro_admin": False
+                }
+
+        actor = {
+                'objectType': 'person',
+                'displayName': 'Jamie Tanna',
+                'image': {'url': 'https://secure.meetupstatic.com/img/noPhoto_80.png'},
+                'id': 'tag:meetup.com:189380737',
+                # numeric_id is our own custom field that always has the source's numeric
+                # user id, if available.
+                'numeric_id': 189380737,
+                'published': '2015-07-02T08:18:21',
+                'url': 'https://www.meetup.com/members/189380737/',
+                'urls': None,
+                'location': {'displayName': 'United Kingdom'},
+                'username': '189380737',
+                'description': None,
+                }
+
+        self.assert_equals(actor, self.meetup.user_to_actor(user_json))
+
     def test_user_url(self):
         self.assert_equals('https://www.meetup.com/members/1234/', self.meetup.user_url(1234))


### PR DESCRIPTION
As found when snarfed was testing snarfed/bridgy#906 with his own
account, which doesn't have a photo associated, a image `None` tries to
get loaded.

We can instead render one of the default images to show the user has no
photo.