### PR TITLE
Bridgy user_to_actor compatibility

### DIFF
--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -218,5 +218,5 @@ class Reddit(source.Source):
     return self.make_activities_base_response(activities)
 
   def user_url(self, username):
-    """Returns the Twitter URL for a given user."""
+    """Returns the Reddit URL for a given user."""
     return 'https://%s/user/%s' % (self.DOMAIN, username)

--- a/granary/tests/test_reddit.py
+++ b/granary/tests/test_reddit.py
@@ -113,8 +113,8 @@ class RedditTest(testutil.TestCase):
     super(RedditTest, self).setUp()
     self.reddit = reddit.Reddit('token-here')
 
-  def test_user_to_actor(self):
-    self.assert_equals(ACTOR, self.reddit.user_to_actor(FakeRedditor()))
+  def test_praw_to_actor(self):
+    self.assert_equals(ACTOR, self.reddit.praw_to_actor(FakeRedditor()))
 
   def test_submission_to_activity(self):
     fake_activities = [self.reddit.praw_to_activity(FakeSubmission(FakeRedditor()),type='submission')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # https://cloud.google.com/appengine/docs/standard/python3/specifying-dependencies
 #
 # Use this to bust that cache: gcloud -q beta app deploy --no-cache ...
-git+https://github.com/snarfed/oauth-dropins.git@master#egg=oauth_dropins
+../oauth-dropins/
 google-cloud-logging~=1.14
 gunicorn~=20.0
 mox3~=0.28

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 # https://cloud.google.com/appengine/docs/standard/python3/specifying-dependencies
 #
 # Use this to bust that cache: gcloud -q beta app deploy --no-cache ...
-../oauth-dropins/
+git+https://github.com/snarfed/oauth-dropins.git@master#egg=oauth_dropins
 google-cloud-logging~=1.14
 gunicorn~=20.0
 mox3~=0.28


### PR DESCRIPTION
See https://github.com/snarfed/bridgy/pull/935 and https://github.com/snarfed/oauth-dropins/pull/35.

In summary, [this line](https://github.com/snarfed/bridgy/blob/1597739f506daf36c9b3781816236462aee70000/models.py#L613) in bridgy assumes that the format of user_json from oauth-dropins will match the input to the granary object's `user_to_actor`.  This is not possible in the current implementation because user_to_actor is accepting a praw Redditor object.  So I've written a helper class to convert from Redditor to dictionary, and then user_to_actor operates on that dictionary.  `praw_to_actor` wraps the two helper functions.