### PR TITLE
Fix: Escape HTML content before embedding in a post

### DIFF
--- a/granary/source.py
+++ b/granary/source.py
@@ -11,7 +11,7 @@ http://activitystrea.ms/specs/json/targeting/1.0/#anchor3
 """
 import collections
 import copy
-from html import unescape
+from html import escape, unescape
 import logging
 import re
 import urllib.parse
@@ -811,16 +811,15 @@ class Source(object, metaclass=SourceMeta):
       obj: AS1 dict with at least url, and optionally also content.
 
     Returns: string, HTML
-
-    Raises: ValueError, if obj['content'] contains raw < or > characters.
     """
     obj = copy.copy(obj)
     for field in 'url', 'content':
       if field not in obj:
         obj.setdefault(field, obj.get('object', {}).get(field, ''))
 
-    if '<' in obj['content'] or '>' in obj['content']:
-      raise ValueError("obj['content'] has unescaped < or > characters!")
+    # allow HTML in posts to be rendered safely, avoiding risk of XSS, but
+    # allowing posts that could contain HTML to be allowed
+    obj['content'] = escape(obj['content'])
 
     # escape URL, but not with urllib.parse.quote, because it quotes a ton of
     # chars we want to pass through, including most unicode chars.

--- a/granary/tests/test_source.py
+++ b/granary/tests/test_source.py
@@ -130,6 +130,11 @@ class FakeSource(Source):
   EMBED_POST = 'foo %(url)s bar'
 
 
+class FakeHTMLSource(Source):
+  DOMAIN = 'fake.com'
+  EMBED_POST = '%(content)s'
+
+
 class SourceTest(testutil.TestCase):
 
   def setUp(self):
@@ -556,9 +561,9 @@ Watching  \t waves
     self.assert_equals('foo http://%3Ca%3Eb bar',
                        self.source.embed_post({'url': 'http://<a>b'}))
 
-  def test_embed_post_checks_content_for_html(self):
-    with self.assertRaises(ValueError):
-      self.source.embed_post({'content': '<xyz>'})
+  def test_embed_post_escapes_html(self):
+    self.assert_equals('x &gt; 2 &amp;&amp; x &lt; 7',
+      FakeHTMLSource().embed_post({'content': 'x > 2 && x < 7' }))
 
   def test_truncate(self):
     """A bunch of tests to exercise the text shortening algorithm."""


### PR DESCRIPTION
As part of [bridgy#880](https://github.com/snarfed/bridgy/issues/880), we added a check to ensure that we would not be
subject to Cross-Site Scripting attacks (XSS).

However, as noted in [bridgy#936](https://github.com/snarfed/bridgy/issues/936), a post that does contain HTML is still
being rejected.

The simplest way to get around this is to escape the HTML tags, so they
can be safely rendered.

Test data via https://stackoverflow.com/a/5072031 adding a new class
which embeds our `content` property.

Closes [bridgy#936](https://github.com/snarfed/bridgy/issues/936).