### PR TITLE
have activity_changed pick up when inReplyTo is changed

### DIFF
--- a/granary/source.py
+++ b/granary/source.py
@@ -816,8 +816,7 @@ class Source(object, metaclass=SourceMeta):
     if obj_b and obj_a:
       reply_b = util.get_list(obj_b,'inReplyTo')
       reply_a = util.get_list(obj_a,'inReplyTo')
-      if reply_b and reply_a:
-        obj_a['inReplyTo'] = util.dedupe_urls(reply_a + reply_b)
+      obj_a['inReplyTo'] = util.dedupe_urls(reply_a + reply_b)
 
   @classmethod
   def embed_post(cls, obj):

--- a/granary/source.py
+++ b/granary/source.py
@@ -814,15 +814,10 @@ class Source(object, metaclass=SourceMeta):
     obj_a = after.get('object', after)
 
     if obj_b and obj_a:
-      reply_b = obj_b.get('inReplyTo')
-      reply_a = obj_a.get('inReplyTo')
+      reply_b = util.get_list(obj_b,'inReplyTo')
+      reply_a = util.get_list(obj_a,'inReplyTo')
       if reply_b and reply_a:
-        reply_new = reply_a + [i for i in reply_b if i not in reply_a]
-        # test to see whether after is activity or
-        if 'object' in after:
-          after['object']['inReplyTo'] = reply_new
-        else:
-          after['inReplyTo'] = reply_new
+        obj_a['inReplyTo'] = util.dedupe_urls(reply_a + reply_b)
 
   @classmethod
   def embed_post(cls, obj):

--- a/granary/source.py
+++ b/granary/source.py
@@ -801,7 +801,7 @@ class Source(object, metaclass=SourceMeta):
     return any(changed(before, after, field, 'activity') or
                changed(obj_b, obj_a, field, 'activity[object]')
                for field in ('objectType', 'verb', 'to', 'content', 'location',
-                             'image'))
+                             'image', 'inReplyTo'))
 
   @classmethod
   def embed_post(cls, obj):

--- a/granary/source.py
+++ b/granary/source.py
@@ -803,6 +803,27 @@ class Source(object, metaclass=SourceMeta):
                for field in ('objectType', 'verb', 'to', 'content', 'location',
                              'image', 'inReplyTo'))
 
+  @staticmethod
+  def append_in_reply_to(before, after):
+    """appends the inReplyTos from the before object to the after object, in place
+
+    Args:
+      before, after: dicts, ActivityStreams activities or objects
+    """
+    obj_b = before.get('object', before)
+    obj_a = after.get('object', after)
+
+    if obj_b and obj_a:
+      reply_b = obj_b.get('inReplyTo')
+      reply_a = obj_a.get('inReplyTo')
+      if reply_b and reply_a:
+        reply_new = reply_a + [i for i in reply_b if i not in reply_a]
+        # test to see whether after is activity or
+        if 'object' in after:
+          after['object']['inReplyTo'] = reply_new
+        else:
+          after['inReplyTo'] = reply_new
+
   @classmethod
   def embed_post(cls, obj):
     """Returns the HTML string for embedding a post object.

--- a/granary/tests/test_source.py
+++ b/granary/tests/test_source.py
@@ -488,6 +488,11 @@ Watching  \t waves
       self.assertFalse(self.source.activity_changed(before, after, log=True),
                                                     '%s\n%s' % (before, after))
 
+    fb_comment_edited_inReplyTo = copy.deepcopy(fb_comment_edited)
+    fb_comment_edited_inReplyTo['inReplyTo'].append({
+      'id': 'tag:fake.com:000000000000000',
+      'url': 'https://www.facebook.com/000000000000000',
+    })
     fb_comment_edited['content'] = 'new content'
     gp_like_edited['to'] = [{'objectType':'group', 'alias':'@private'}]
 
@@ -496,6 +501,7 @@ Watching  \t waves
     fb_rsvp = RSVP_YES
 
     for before, after in ((fb_comment, fb_comment_edited),
+                          (fb_comment, fb_comment_edited_inReplyTo),
                           (gp_like, gp_like_edited),
                           (fb_invite, fb_rsvp)):
       self.assertTrue(self.source.activity_changed(before, after, log=True),

--- a/granary/tests/test_source.py
+++ b/granary/tests/test_source.py
@@ -507,6 +507,21 @@ Watching  \t waves
       self.assertTrue(self.source.activity_changed(before, after, log=True),
                                                    '%s\n%s' % (before, after))
 
+  def test_append_in_reply_to(self):
+    fb_comment_before = copy.deepcopy(COMMENT)
+    fb_comment_after_same = copy.deepcopy(fb_comment_before)
+    self.source.append_in_reply_to(fb_comment_before,fb_comment_after_same)
+    self.assertEqual(COMMENT,fb_comment_before)
+    self.assertEqual(COMMENT,fb_comment_after_same)
+
+    fb_comment_after_diff = copy.deepcopy(fb_comment_before)
+    fb_comment_after_targ = copy.deepcopy(fb_comment_before)
+    fb_comment_after_diff['inReplyTo'] = ['new']
+    fb_comment_after_targ['inReplyTo'] = fb_comment_after_diff.get('inReplyTo')+fb_comment_before.get('inReplyTo')
+    self.source.append_in_reply_to(fb_comment_before,fb_comment_after_diff)
+    self.assertEqual(fb_comment_after_targ,fb_comment_after_diff)
+
+
   def test_sources_global(self):
     self.assertEqual(facebook.Facebook, source.sources['facebook'])
     self.assertEqual(instagram.Instagram, source.sources['instagram'])


### PR DESCRIPTION
Based on the discussion on https://github.com/snarfed/bridgy/issues/933, it seems that sometimes mastodon doesn't populate all of it's descendants immediately, which can lead to some inReplyTos being missed.  This PR changes `activity_changed` to pick up changes in the inReplyTo field and trigger. 

Regarding whether the new activity should replace or be merged in, it seems like it would be OK to just replace because the new activity ought to have all the inReplyTos associated with it (assuming they're all there on the mastodon side eventually).  Correct me if I'm missing something.