### PR TITLE
catch exception when redditor account is not available

### DIFF
--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -49,9 +49,9 @@ class Reddit(source.Source):
     """
     try:
       user = reddit.praw_to_user(praw_user)
-      return self.user_to_actor(user)
     except NotFound:
       return {}
+    return self.user_to_actor(user)
 
   def user_to_actor(self, user):
     """Converts a dict user to an actor.

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -33,14 +33,6 @@ class Reddit(source.Source):
   BASE_URL = 'https://reddit.com'
   NAME = 'Reddit'
 
-  missing_user = {
-    'name': 'user_not_found',
-    'subreddit': None,
-    'icon_img': 'null_img',
-    'id': 'null_id',
-    'created_utc': None
-  }
-
   def __init__(self, refresh_token):
     self.refresh_token = refresh_token
 
@@ -57,9 +49,9 @@ class Reddit(source.Source):
     """
     try:
       user = reddit.praw_to_user(praw_user)
+      return self.user_to_actor(user)
     except NotFound:
-      user = missing_user
-    return self.user_to_actor(user)
+      return {}
 
   def user_to_actor(self, user):
     """Converts a dict user to an actor.

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -18,6 +18,7 @@ import re
 import urllib.parse, urllib.request
 
 import praw
+from prawcore.exceptions import NotFound
 
 def get_reddit_api(refresh_token):
   return praw.Reddit(client_id=reddit.REDDIT_APP_KEY,
@@ -32,6 +33,14 @@ class Reddit(source.Source):
   BASE_URL = 'https://reddit.com'
   NAME = 'Reddit'
 
+  missing_user = {
+    'name': 'user_not_found',
+    'subreddit': None,
+    'icon_img': 'null_img',
+    'id': 'null_id',
+    'created_utc': None
+  }
+
   def __init__(self, refresh_token):
     self.refresh_token = refresh_token
 
@@ -45,7 +54,10 @@ class Reddit(source.Source):
     Returns:
       an ActivityStreams actor dict, ready to be JSON-encoded
     """
-    user = reddit.praw_to_user(praw_user)
+    try:
+      user = reddit.praw_to_user(praw_user)
+    except NotFound:
+      user = missing_user
     return self.user_to_actor(user)
 
   def user_to_actor(self, user):

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -46,6 +46,7 @@ class Reddit(source.Source):
 
   def praw_to_actor(self, praw_user):
     """Converts a praw Redditor to an actor.
+    Note that praw_to_user funciton makes external calls to fetch data from reddit API
     https://praw.readthedocs.io/en/latest/code_overview/models/redditor.html
 
     Args:
@@ -108,6 +109,7 @@ class Reddit(source.Source):
   def praw_to_object(self, thing, type):
     """
     Converts a praw object to an object. currently only returns public content
+    Note that this will make external API calls to lazily load some attrs
 
     Args:
       thing: a praw object, Submission or Comment
@@ -166,6 +168,7 @@ class Reddit(source.Source):
     """Converts a praw submission or comment to an activity.
     https://praw.readthedocs.io/en/latest/code_overview/models/submission.html
     https://praw.readthedocs.io/en/latest/code_overview/models/comment.html
+    Note that this will make external API calls to lazily load some attrs
 
     Args:
       thing: a praw object, Submission or Comment

--- a/granary/tests/test_reddit.py
+++ b/granary/tests/test_reddit.py
@@ -166,11 +166,25 @@ ACTOR = {
   'description': 'https://bonkerfield.org https://viewfoil.bonkerfield.org',
   }
 
+MISSING_ACTOR = {
+  'displayName': 'user_not_found',
+  'id': 'tag:reddit.com:user_not_found',
+  'image': {'url': 'null_img'},
+  'numeric_id': 'null_id',
+  'objectType': 'person',
+  'url': 'https://reddit.com/user/user_not_found',
+  'username': 'user_not_found'
+  }
+
+
 class RedditTest(testutil.TestCase):
 
   def setUp(self):
     super(RedditTest, self).setUp()
     self.reddit = reddit.Reddit('token-here')
+
+  def test_missing_user_to_actor(self):
+    self.assert_equals(MISSING_ACTOR, self.reddit.user_to_actor(self.reddit.missing_user))
 
   def test_praw_to_actor(self):
     self.assert_equals(ACTOR, self.reddit.praw_to_actor(FakeRedditor()))

--- a/granary/tests/test_reddit.py
+++ b/granary/tests/test_reddit.py
@@ -6,6 +6,8 @@ from granary import reddit
 import copy
 import json
 
+from prawcore.exceptions import NotFound
+
 class FakeRedditor():
   """ to mock https://praw.readthedocs.io/en/latest/code_overview/models/redditor.html
   """
@@ -24,6 +26,18 @@ class FakeRedditor():
   icon_img = 'https://styles.redditmedia.com/t5_2az095/styles/profileIcon_ek6onop1xbf41.png'
 
   created_utc = 1576950011.0
+
+class FakeMissingRedditor():
+  """ to mock https://praw.readthedocs.io/en/latest/code_overview/models/redditor.html
+  """
+
+  name = 'mr_missing'
+
+  @property
+  def subreddit(self):
+    class FakeResponse():
+      status_code = '404'
+    raise NotFound(FakeResponse())
 
 
 class FakeSubmission():
@@ -166,16 +180,7 @@ ACTOR = {
   'description': 'https://bonkerfield.org https://viewfoil.bonkerfield.org',
   }
 
-MISSING_ACTOR = {
-  'displayName': 'user_not_found',
-  'id': 'tag:reddit.com:user_not_found',
-  'image': {'url': 'null_img'},
-  'numeric_id': 'null_id',
-  'objectType': 'person',
-  'url': 'https://reddit.com/user/user_not_found',
-  'username': 'user_not_found'
-  }
-
+MISSING_ACTOR = {}
 
 class RedditTest(testutil.TestCase):
 
@@ -184,7 +189,7 @@ class RedditTest(testutil.TestCase):
     self.reddit = reddit.Reddit('token-here')
 
   def test_missing_user_to_actor(self):
-    self.assert_equals(MISSING_ACTOR, self.reddit.user_to_actor(self.reddit.missing_user))
+    self.assert_equals(MISSING_ACTOR, self.reddit.praw_to_actor(FakeMissingRedditor()))
 
   def test_praw_to_actor(self):
     self.assert_equals(ACTOR, self.reddit.praw_to_actor(FakeRedditor()))


### PR DESCRIPTION
when a reddit account is not available praw throws a 404 error.  I was thinking that we could catch the 404 and just fill in the user with a generic "missing" account.  

Other alternative is to throw away the comment, but that doesn't seem ideal either.  Open to suggestions.