### PR TITLE
fixing missing is_subreddit attribute, adding tests for other missing attributes in praw objects

### DIFF
--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -112,14 +112,11 @@ class Reddit(source.Source):
       """
     obj = {}
 
-    if any([not hasattr(thing,a) for a in ['id','author','permalink']]):
-      return {}
-
-    id = thing.id
+    id = getattr(thing,'id',None)
     if not id:
       return {}
 
-    published = util.maybe_timestamp_to_iso8601(thing.created_utc)
+    published = util.maybe_timestamp_to_iso8601(getattr(thing,'created_utc',None))
 
     obj = {
       'id': self.tag_uri(id),
@@ -130,7 +127,7 @@ class Reddit(source.Source):
         }],
       }
 
-    user = thing.author
+    user = getattr(thing,'author',None)
     if user:
       obj['author'] = self.praw_to_actor(user)
       username = obj['author'].get('username')
@@ -138,26 +135,22 @@ class Reddit(source.Source):
     obj['url'] = self.BASE_URL + thing.permalink
 
     if type == 'submission':
-      if any([not hasattr(thing,a) for a in ['title','selftext']]):
-        return {}
-      obj['content'] = thing.title
+      obj['content'] = getattr(thing,'title',None)
       obj['objectType'] = 'note'
       obj['tags'] = [
           {'objectType': 'article',
            'url': t,
            'displayName': t,
-           } for t in util.extract_links(thing.selftext)
+           } for t in util.extract_links(getattr(thing,'selftext',None))
         ]
     elif type == 'comment':
-      if not hasattr(thing,'body_html'):
-        return {}
-      obj['content'] = thing.body_html
+      obj['content'] = getattr(thing,'body_html',None)
       obj['objectType'] = 'comment'
       reply_to = thing.parent()
       if reply_to:
         obj['inReplyTo'] = [{
-          'id': self.tag_uri(reply_to.id),
-          'url': self.BASE_URL + reply_to.permalink,
+          'id': self.tag_uri(getattr(reply_to,'id',None)),
+          'url': self.BASE_URL + getattr(reply_to,'permalink',None),
           }]
 
     return self.postprocess_object(obj)
@@ -178,8 +171,7 @@ class Reddit(source.Source):
     """
     obj = self.praw_to_object(thing, type)
     actor = obj.get('author')
-    if any([not hasattr(thing,a) for a in ['id','permalink']]):
-      return {}
+
     id = getattr(thing,'id',None)
     if not id:
       return {}
@@ -187,7 +179,7 @@ class Reddit(source.Source):
     activity = {
       'verb': 'post',
       'id': id,
-      'url': self.BASE_URL + thing.permalink,
+      'url': self.BASE_URL + getattr(thing,'permalink',None),
       'actor': actor,
       'object': obj
       }
@@ -211,7 +203,7 @@ class Reddit(source.Source):
       # for v0 we will use just the top level comments because threading is hard
       subm.comments.replace_more()
       replies = []
-      for top_level_comment in subm.comments:
+      for top_level_comment in getattr(subm,'comments',None):
         replies.append(self.praw_to_activity(top_level_comment, 'comment'))
 
       items = [r.get('object') for r in replies]

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -112,11 +112,11 @@ class Reddit(source.Source):
       """
     obj = {}
 
-    id = getattr(thing,'id',None)
+    id = getattr(thing, 'id', None)
     if not id:
       return {}
 
-    published = util.maybe_timestamp_to_iso8601(getattr(thing,'created_utc',None))
+    published = util.maybe_timestamp_to_iso8601(getattr(thing, 'created_utc', None))
 
     obj = {
       'id': self.tag_uri(id),
@@ -127,7 +127,7 @@ class Reddit(source.Source):
         }],
       }
 
-    user = getattr(thing,'author',None)
+    user = getattr(thing, 'author', None)
     if user:
       obj['author'] = self.praw_to_actor(user)
       username = obj['author'].get('username')
@@ -135,22 +135,22 @@ class Reddit(source.Source):
     obj['url'] = self.BASE_URL + thing.permalink
 
     if type == 'submission':
-      obj['content'] = getattr(thing,'title',None)
+      obj['content'] = getattr(thing, 'title', None)
       obj['objectType'] = 'note'
       obj['tags'] = [
           {'objectType': 'article',
            'url': t,
            'displayName': t,
-           } for t in util.extract_links(getattr(thing,'selftext',None))
+           } for t in util.extract_links(getattr(thing, 'selftext', None))
         ]
     elif type == 'comment':
-      obj['content'] = getattr(thing,'body_html',None)
+      obj['content'] = getattr(thing, 'body_html', None)
       obj['objectType'] = 'comment'
       reply_to = thing.parent()
       if reply_to:
         obj['inReplyTo'] = [{
-          'id': self.tag_uri(getattr(reply_to,'id',None)),
-          'url': self.BASE_URL + getattr(reply_to,'permalink',None),
+          'id': self.tag_uri(getattr(reply_to, 'id', None)),
+          'url': self.BASE_URL + getattr(reply_to, 'permalink', None),
           }]
 
     return self.postprocess_object(obj)
@@ -172,14 +172,14 @@ class Reddit(source.Source):
     obj = self.praw_to_object(thing, type)
     actor = obj.get('author')
 
-    id = getattr(thing,'id',None)
+    id = getattr(thing, 'id', None)
     if not id:
       return {}
 
     activity = {
       'verb': 'post',
       'id': id,
-      'url': self.BASE_URL + getattr(thing,'permalink',None),
+      'url': self.BASE_URL + getattr(thing, 'permalink', None),
       'actor': actor,
       'object': obj
       }
@@ -203,7 +203,7 @@ class Reddit(source.Source):
       # for v0 we will use just the top level comments because threading is hard
       subm.comments.replace_more()
       replies = []
-      for top_level_comment in getattr(subm,'comments',None):
+      for top_level_comment in getattr(subm, 'comments', None):
         replies.append(self.praw_to_activity(top_level_comment, 'comment'))
 
       items = [r.get('object') for r in replies]

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -112,7 +112,7 @@ class Reddit(source.Source):
       """
     obj = {}
 
-    id = thing.id
+    id = getattr(thing,'id',None)
     if not id:
       return {}
 
@@ -171,10 +171,13 @@ class Reddit(source.Source):
     """
     obj = self.praw_to_object(thing, type)
     actor = obj.get('author')
+    id = getattr(thing,'id',None)
+    if not id:
+      return {}
 
     activity = {
       'verb': 'post',
-      'id': thing.id,
+      'id': id,
       'url': self.BASE_URL + thing.permalink,
       'actor': actor,
       'object': obj

--- a/granary/reddit.py
+++ b/granary/reddit.py
@@ -112,7 +112,10 @@ class Reddit(source.Source):
       """
     obj = {}
 
-    id = getattr(thing,'id',None)
+    if any([not hasattr(thing,a) for a in ['id','author','permalink']]):
+      return {}
+
+    id = thing.id
     if not id:
       return {}
 
@@ -135,6 +138,8 @@ class Reddit(source.Source):
     obj['url'] = self.BASE_URL + thing.permalink
 
     if type == 'submission':
+      if any([not hasattr(thing,a) for a in ['title','selftext']]):
+        return {}
       obj['content'] = thing.title
       obj['objectType'] = 'note'
       obj['tags'] = [
@@ -144,6 +149,8 @@ class Reddit(source.Source):
            } for t in util.extract_links(thing.selftext)
         ]
     elif type == 'comment':
+      if not hasattr(thing,'body_html'):
+        return {}
       obj['content'] = thing.body_html
       obj['objectType'] = 'comment'
       reply_to = thing.parent()
@@ -171,6 +178,8 @@ class Reddit(source.Source):
     """
     obj = self.praw_to_object(thing, type)
     actor = obj.get('author')
+    if any([not hasattr(thing,a) for a in ['id','permalink']]):
+      return {}
     id = getattr(thing,'id',None)
     if not id:
       return {}

--- a/granary/tests/test_reddit.py
+++ b/granary/tests/test_reddit.py
@@ -39,14 +39,6 @@ class FakeMissingRedditor():
       status_code = '404'
     raise NotFound(FakeResponse())
 
-class FakeSuspendedRedditor():
-  """ to mock https://praw.readthedocs.io/en/latest/code_overview/models/redditor.html
-  """
-
-  name = 'mr_suspended'
-  is_suspended = True
-
-
 class FakeRedditorBroken():
   """ to test when Redditor object has no attributes
   """
@@ -64,11 +56,6 @@ class FakeSubmission():
   def __init__(self, fake_redditor):
     self.author = fake_redditor
 
-class FakeSubmissionBroken():
-  """ to test when Submission object has no attributes
-  """
-  pass
-
 class FakeComment():
   """ to mock https://praw.readthedocs.io/en/latest/code_overview/models/comment.html
   """
@@ -83,11 +70,6 @@ class FakeComment():
 
   def parent(self):
     return self._parent
-
-class FakeCommentBroken():
-  """ to test when Comment object has no attributes
-  """
-  pass
 
 ACTIVITY = {
   'filtered': False,
@@ -212,13 +194,13 @@ class RedditTest(testutil.TestCase):
     self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_actor(FakeMissingRedditor()))
 
   def test_suspended_user_to_actor(self):
-    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_actor(FakeSuspendedRedditor()))
+    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_actor(util.Struct(name='mr_suspended', is_suspended=True)))
 
   def test_praw_to_actor(self):
     self.assert_equals(ACTOR, self.reddit.praw_to_actor(FakeRedditor()))
 
   def test_broken_praw_to_actor(self):
-    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_actor(FakeRedditorBroken()))
+    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_actor(util.Struct()))
 
   def test_praw_to_comment(self):
     fake_author = FakeRedditor()
@@ -226,11 +208,11 @@ class RedditTest(testutil.TestCase):
     self.assert_equals(COMMENT_OBJECT, self.reddit.praw_to_object(FakeComment(fake_sub,fake_author),'comment'))
 
   def test_broken_praw_to_comment(self):
-    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_object(FakeCommentBroken(),'comment'))
+    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_object(util.Struct(),'comment'))
 
   def test_submission_to_activity(self):
     fake_activities = [self.reddit.praw_to_activity(FakeSubmission(FakeRedditor()),type='submission')]
     self.assert_equals(ACTIVITY, self.reddit.make_activities_base_response(fake_activities))
 
   def test_broken_submission_to_object(self):
-    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_activity(FakeSubmissionBroken(),type='submission'))
+    self.assert_equals(MISSING_OBJECT, self.reddit.praw_to_activity(util.Struct(),type='submission'))


### PR DESCRIPTION
We currently rely on the returned objects from praw having certain attributes which are not necessarily guaranteed.  This change allows us to return empty objects if the praw objects are missing necessary attributes.