### PR TITLE
update unit tests to behave with oauth default user agent

### DIFF
--- a/granary/tests/test_facebook.py
+++ b/granary/tests/test_facebook.py
@@ -30,6 +30,7 @@ from ..facebook import (
   API_USER_EVENTS,
   Facebook,
   M_HTML_BASE_URL,
+  SCRAPE_USER_AGENT
 )
 from .. import source
 
@@ -1365,8 +1366,10 @@ class FacebookTest(testutil.TestCase):
 
   def expect_requests_get(self, url, resp='', cookie=None, **kwargs):
     kwargs.setdefault('allow_redirects', False)
+    # override user agent for facebook scraping (specific to facebook tests)
+    kwargs.setdefault('headers', {})['User-Agent'] = SCRAPE_USER_AGENT
     if cookie:
-      kwargs.setdefault('headers', {})['Cookie'] = cookie
+      kwargs['headers']['Cookie'] = cookie
     url = urllib.parse.urljoin(M_HTML_BASE_URL, url)
     return super(FacebookTest, self).expect_requests_get(url, resp, **kwargs)
 

--- a/granary/tests/test_instagram.py
+++ b/granary/tests/test_instagram.py
@@ -1247,9 +1247,6 @@ class InstagramTest(testutil.TestCase):
 
   def expect_requests_get(self, url, resp='', cookie=None, **kwargs):
     kwargs.setdefault('allow_redirects', False)
-
-    
-    
     if cookie:
       # instagram scraper sets USER-AGENT and App ID headers when cookie that
       # begins with sessionid= is set

--- a/granary/tests/test_instagram.py
+++ b/granary/tests/test_instagram.py
@@ -13,7 +13,7 @@ from oauth_dropins.webutil.util import json_dumps, json_loads
 import requests
 
 from .. import instagram
-from ..instagram import HTML_BASE_URL, Instagram
+from ..instagram import HTML_BASE_URL, Instagram, HEADERS
 from .. import source
 
 
@@ -1247,8 +1247,13 @@ class InstagramTest(testutil.TestCase):
 
   def expect_requests_get(self, url, resp='', cookie=None, **kwargs):
     kwargs.setdefault('allow_redirects', False)
+
+    
+    
     if cookie:
-      kwargs.setdefault('headers', {})['Cookie'] = 'sessionid=' + cookie
+      # instagram scraper sets USER-AGENT and App ID headers when cookie that
+      # begins with sessionid= is set
+      kwargs.setdefault('headers', HEADERS)['Cookie'] = 'sessionid=' + cookie
     if not url.startswith('http'):
       url = HTML_BASE_URL + url
     return super(InstagramTest, self).expect_requests_get(url, resp, **kwargs)


### PR DESCRIPTION
This PR relates to my bridgy issue open [here](https://github.com/snarfed/bridgy/issues/1099).

The purpose of this PR is to bring some of the tests for granary up to date with the new default user agent behaviour in webutil and oauth-dropins. In particular, Facebook and Instagram tests were failing since the browser-like user agent which was being used for scraping those two silos was not being set up properly and was causing an assert error in the `check_headers` helper method within the test utils module in webutil

I wasn't too sure if the original test behaviour may even have been wrong or whether I have completely misunderstood how the test works and now broken it. My solution was to inject the user-agent strings in the `expect_requests_get` helper class of each test class respectively (for instagram we only inject this when cookie is set as per the scraper behaviour).

Related PRs:

 -  [oauth-dropins#73](https://github.com/snarfed/oauth-dropins/pull/73)
 -  [webutil#5](https://github.com/snarfed/webutil/pull/5)