### PR TITLE
Fix: Correctly trim Twitter alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,11 @@ Changelog
 ---
 ### 4.1 - unreleased
 
+- _Non-breaking changes_
+
+* Twitter
+  * Correctly trim Twitter alt text
+
 ### 4.0 - 2022-03-23
 
 _Breaking changes:_

--- a/granary/tests/test_twitter.py
+++ b/granary/tests/test_twitter.py
@@ -2653,6 +2653,78 @@ the caption. extra long so we can check that it accounts for the pic-twitter-com
       },
     })
 
+  def test_create_with_photo_alt_is_not_trimmed_when_short(self):
+    obj = {
+      'objectType': 'note',
+      'image': {
+        'url': 'http://my/picture.png',
+        'displayName': 'Black Cat\'s face framed in a window of a grey hidey hole in his tower, looking a little bit crabby',
+      },
+    }
+
+    # test preview
+    preview = self.twitter.preview_create(obj)
+    self.assertEqual('<span class="verb">tweet</span>:', preview.description)
+    self.assertEqual('<br /><br /><img src="http://my/picture.png" alt="Black Cat\'s face framed in a window of a grey hidey hole in his tower, looking a little bit crabby" />',
+                     preview.content)
+
+    # test create
+    self.expect_urlopen('http://my/picture.png', 'picture response',
+                        response_headers={'Content-Length': 3})
+    self.expect_requests_post(twitter.API_UPLOAD_MEDIA,
+                              json_dumps({'media_id_string': '123'}),
+                              files={'media': 'picture response'},
+                              headers=mox.IgnoreArg())
+    self.expect_requests_post(twitter.API_MEDIA_METADATA,
+                              json={'media_id': '123',
+                                    'alt_text': {'text': 'Black Cat\'s face framed in a window of a grey hidey hole in his tower, looking a little bit crabby'}},
+                              headers=mox.IgnoreArg())
+    self.expect_urlopen(twitter.API_POST_TWEET, {'url': 'http://posted/picture'},
+                        params=(
+                          # sorted; order matters.
+                          ('media_ids', '123'),
+                          ('status', ''),
+                        ))
+    self.mox.ReplayAll()
+    self.assert_equals({'url': 'http://posted/picture', 'type': 'post'},
+                       self.twitter.create(obj).content)
+
+  def test_create_with_photo_alt_trimmed_when_too_large(self):
+    obj = {
+      'objectType': 'note',
+      'image': {
+        'url': 'http://my/picture.png',
+        'displayName': '1a871f1abf22f3963bcf65f9bf9084d85c70d23f59d36b21c9776cf4e8e5919150e753e20c39afb353ca0253062794f931468e48c111fdc9549eba886717f8578ba92ef237b762663195ba73ab61339795a7e902e90548813c77cfa9381e459ec0dd04d6122b00e75906cf52363a1f61d6c70df6631020bc102e28c4c9895302fbcc19f4912c5a71334d09c84d279ec9deb1e6b23cb82a5ed7145c9d6320c04dbc2f0a9a0b99a61fd4e807782af4e13567db8759be6e5543c9da3c9ba72ca29266fca72652d29d961939961fb1acd622d0b and this extra bit will be trimmed',
+      },
+    }
+
+    # test preview
+    preview = self.twitter.preview_create(obj)
+    self.assertEqual('<span class="verb">tweet</span>:', preview.description)
+    self.assertEqual('<br /><br /><img src="http://my/picture.png" alt="1a871f1abf22f3963bcf65f9bf9084d85c70d23f59d36b21c9776cf4e8e5919150e753e20c39afb353ca0253062794f931468e48c111fdc9549eba886717f8578ba92ef237b762663195ba73ab61339795a7e902e90548813c77cfa9381e459ec0dd04d6122b00e75906cf52363a1f61d6c70df6631020bc102e28c4c9895302fbcc19f4912c5a71334d09c84d279ec9deb1e6b23cb82a5ed7145c9d6320c04dbc2f0a9a0b99a61fd4e807782af4e13567db8759be6e5543c9da3c9ba72ca29266fca72652d29d961939961fb1acd622d0b and this extra bit will be trimmed" />',
+                     preview.content)
+
+    # test create
+    self.expect_urlopen('http://my/picture.png', 'picture response',
+                        response_headers={'Content-Length': 3})
+    self.expect_requests_post(twitter.API_UPLOAD_MEDIA,
+                              json_dumps({'media_id_string': '123'}),
+                              files={'media': 'picture response'},
+                              headers=mox.IgnoreArg())
+    self.expect_requests_post(twitter.API_MEDIA_METADATA,
+                              json={'media_id': '123',
+                                    'alt_text': {'text': '1a871f1abf22f3963bcf65f9bf9084d85c70d23f59d36b21c9776cf4e8e5919150e753e20c39afb353ca0253062794f931468e48c111fdc9549eba886717f8578ba92ef237b762663195ba73ab61339795a7e902e90548813c77cfa9381e459ec0dd04d6122b00e75906cf52363a1f61d6c70df6631020bc102e28c4c9895302fbcc19f4912c5a71334d09c84d279ec9deb1e6b23cb82a5ed7145c9d6320c04dbc2f0a9a0b99a61fd4e807782af4e13567db8759be6e5543c9da3c9ba72ca29266fca72652d29d961939961fb1acd622d...'}},
+                              headers=mox.IgnoreArg())
+    self.expect_urlopen(twitter.API_POST_TWEET, {'url': 'http://posted/picture'},
+                        params=(
+                          # sorted; order matters.
+                          ('media_ids', '123'),
+                          ('status', ''),
+                        ))
+    self.mox.ReplayAll()
+    self.assert_equals({'url': 'http://posted/picture', 'type': 'post'},
+                       self.twitter.create(obj).content)
+
   def test_create_with_video_wait_for_processing(self):
     self.twitter.TRUNCATE_TEXT_LENGTH = 140
 

--- a/granary/twitter.py
+++ b/granary/twitter.py
@@ -932,7 +932,7 @@ class Twitter(source.Source):
 
       alt = image.get('displayName')
       if alt:
-        alt = util.ellipsize(alt, chars=MAX_ALT_LENGTH)
+        alt = util.ellipsize(alt, words=1000, chars=MAX_ALT_LENGTH)
         headers = twitter_auth.auth_header(
           API_MEDIA_METADATA, self.access_token_key, self.access_token_secret, 'POST')
         resp = util.requests_post(


### PR DESCRIPTION
As noted in [0], Twitter alt text is getting pre-emptively trimmed.

This is a fixup for the original introduction in 9a61adc5, which did not
pass in a `words`, therefore the alt text is getting trimmed at the
default 14 words.

We can use 1000 words, as it's very unlikely to be met before 420
characters in the alt text.

[0]: https://github.com/snarfed/bridgy/issues/1175
