### PR TITLE
AO3: add the ability to use AO3 works pages as the input

### DIFF
--- a/granary/ao3.py
+++ b/granary/ao3.py
@@ -1,0 +1,67 @@
+import datetime
+from bs4 import BeautifulSoup
+import requests
+
+from granary import source
+
+USER_AGENT = 'Granary feed bot - for support contact sarajaksa@sarajaksa.eu'
+
+
+class ArchiveOfOurOwn(source.Source):
+    DOMAIN = 'https://archiveofourown.org'
+    URL_BASE = 'https://archiveofourown.org'
+    NAME = 'ArchiveOfOurOwn'
+
+    def get_stories_from_single_page(self, html):
+        activities_works = []
+
+        soup = BeautifulSoup(html, features='lxml')
+        works_elements = soup.find_all('li', class_='work')
+        for work in works_elements:
+
+            work_id = work.get('id').split('_')[1]
+            chapter_id = 0
+            chapters_element_link = work.find('dd', class_='chapters').find('a')
+            if chapters_element_link:
+                chapter_link_href = chapters_element_link.get('href')
+                chapter_id = chapter_link_href.split('/chapters/')[1]
+            work_and_chapter_id = f'{work_id}-{chapter_id}'
+
+            date_updated_string = work.find('p', class_='datetime').text
+            date_updated = datetime.datetime.strptime(date_updated_string, '%d %b %Y').strftime('%Y-%m-%d')
+
+            author = [author.text for author in work.find_all('a', rel='author')]
+            if not len(author):
+                author = [work.find('h4').encode_contents().decode().split('<!-- do not cache -->')[1].strip()]
+
+            author = ", ".join(author)
+
+            work_url = f'https://archiveofourown.org/works/{work_id}'
+            if chapter_id:
+                work_url += f'/chapters/{chapter_id}'
+
+            work_object = {
+                'id': work_and_chapter_id,
+                'objectType': 'work',
+                'verb': 'post',
+                'published': date_updated,
+                'username': author,
+                'content': work.encode_contents().decode(),
+                'content_is_html': True,
+                'url': work_url,
+            }
+
+            activities_works.append({
+                'objectType': 'activity',
+                'verb': 'post',
+                'object': work_object,
+            })
+
+        return activities_works
+
+    def get_stories(self, url):
+        stories_response = requests.get(url, headers={'User-Agent': USER_AGENT})
+        return self.get_stories_from_single_page(stories_response.text)
+
+    def url_to_activities(self, url=None):
+        return self.get_stories(url)


### PR DESCRIPTION
This code adds the ability, to change any page with the works on it, to activities. This will allow, for example, to create the RSS feeds for any searches or for specific users, and not just tags.

My main goal is to be able to eventually backfeed the AO3 activities with Bridgy (since this was requested from me by somebody else). But this seemed to be the smallest piece, that would still provide some useful functionality to me and hopefully also somebody else. 

For example, I do have one saved search, that I could move to RSS feed with this, instead of checking manually.

I did not manage to run the project locally, but I did test is as a library. The conversion to RSS and jsonfeed work well. Not sure if I missed something, just because of the way I tested the code. 