### PR TITLE
Align handle/DID handling with AT Proto spec

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -93,7 +93,7 @@ def did_web_to_url(did):
 
   Returns: str
   """
-  if not did or not DID_WEB_PATTERN.search(did):
+  if not did or not DID_WEB_PATTERN.match(did):
     raise ValueError(f'Invalid did:web: {did}')
 
   host = did.removeprefix('did:web:')
@@ -182,7 +182,7 @@ def from_as1(obj, from_url=None):
     username = obj.get('username')
     parsed = urllib.parse.urlparse(url)
     domain = parsed.netloc
-    if username and HANDLE_PATTERN.search(username):
+    if username and HANDLE_PATTERN.match(username):
       handle = username
     elif url:
       handle = domain

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -173,6 +173,7 @@ def from_as1(obj, from_url=None):
     if not url and id:
       parsed = util.parse_tag_uri(id)
       if parsed:
+        # This is only really formatted as a URL to keep url_to_did_web happy.
         url = f'https://{parsed[0]}'
     try:
       did_web = url_to_did_web(url)

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -71,6 +71,10 @@ def url_to_did_web(url):
   parsed = urllib.parse.urlparse(url)
   if not parsed.hostname:
     raise ValueError(f'Invalid URL: {url}')
+  if parsed.netloc != parsed.hostname:
+    logger.warning(f"URL {url} contained a port, which will not be included in the DID.")
+  if parsed.path and parsed.path != "/":
+    logger.warning(f"URL {url} contained a path,  which will not be included in the DID.")
 
   return f'did:web:{parsed.hostname}'
 

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -169,7 +169,7 @@ def from_as1(obj, from_url=None):
     if not url and id:
       parsed = util.parse_tag_uri(id)
       if parsed:
-        url = f'http://{parsed[0]}'
+        url = f'https://{parsed[0]}'
     try:
       did_web = url_to_did_web(url)
     except ValueError as e:

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -167,7 +167,6 @@ def from_as1(obj, from_url=None):
     url = util.get_url(obj)
     id = obj.get('id')
     if not url and id:
-      url = ''
       parsed = util.parse_tag_uri(id)
       if parsed:
         url = f'http://{parsed[0]}'

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -199,7 +199,7 @@ def from_as1(obj, from_url=None):
       'description': obj.get('summary'),
       'avatar': util.get_url(obj, 'image'),
       'banner': banner,
-      'did': did_web,
+      'did': id if id and id.startswith('did:') else did_web,
       # this is a DID
       # atproto/packages/pds/src/api/app/bsky/actor/getProfile.ts#38
       # TODO: should be more specific than domain, many users will be on shared

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -264,18 +264,16 @@ class BlueskyTest(testutil.TestCase):
 
     self.assertEqual('did:web:foo.com', url_to_did_web('https://foo.com'))
     self.assertEqual('did:web:foo.com', url_to_did_web('https://foo.com/'))
-    self.assertEqual('did:web:foo.com%3A3000', url_to_did_web('https://foo.com:3000'))
-    self.assertEqual('did:web:bar.com:baz:baj', url_to_did_web('https://bar.com/baz/baj'))
+    self.assertEqual('did:web:foo.com', url_to_did_web('https://foo.com:3000'))
+    self.assertEqual('did:web:foo.bar.com', url_to_did_web('https://foo.bar.com/baz/baj'))
 
   def test_did_web_to_url(self):
-    for bad in None, '', 'foo' 'https://bar.com':
+    for bad in None, '', 'foo' 'https://bar.com', 'did:web:foo.com:path':
       with self.assertRaises(ValueError):
         did_web_to_url(bad)
 
     self.assertEqual('https://foo.com/', did_web_to_url('did:web:foo.com'))
-    self.assertEqual('https://foo.com/', did_web_to_url('did:web:foo.com:'))
-    self.assertEqual('https://foo.com:3000/', did_web_to_url('did:web:foo.com%3A3000'))
-    self.assertEqual('https://bar.com/baz/baj', did_web_to_url('did:web:bar.com:baz:baj'))
+    self.assertEqual('https://foo.bar.com/', did_web_to_url('did:web:foo.bar.com'))
 
   def test_user_url(self):
     self.assertEqual('https://bsky.app/profile/snarfed.org',
@@ -347,11 +345,10 @@ class BlueskyTest(testutil.TestCase):
   def test_from_as1_actor_handle(self):
     for expected, fields in (
         ('', {}),
-        ('fooey', {'username': 'fooey'}),
-        ('fooey@my', {'username': 'fooey', 'url': 'http://my/url', 'id': 'tag:nope'}),
-        ('foo,2001:extra', {'id': 'tag:foo,2001:extra'}),
-        ('url/with/path', {'url': 'http://url/with/path'}),
-        ('foo', {'url': 'http://foo/'}),
+        ('fooey.bsky.social', {'username': 'fooey.bsky.social'}),
+        ('fooey.com', {'username': 'fooey.com', 'url': 'http://my/url', 'id': 'tag:nope'}),
+        ('foo.com', {'url': 'http://foo.com'}),
+        ('foo.com', {'url': 'http://foo.com/path'}),
     ):
       self.assert_equals(expected, from_as1({
         'objectType' : 'person',
@@ -360,7 +357,7 @@ class BlueskyTest(testutil.TestCase):
 
   def test_from_as1_actor_id_not_url(self):
     """Tests error handling when attempting to generate did:web."""
-    self.assertEqual('', from_as1({
+    self.assertEqual('did:web:foo.com', from_as1({
       'objectType' : 'person',
       'id': 'tag:foo.com,2001:bar',
     })['did'])

--- a/granary/tests/testdata/actor.as-from-bsky.json
+++ b/granary/tests/testdata/actor.as-from-bsky.json
@@ -1,7 +1,7 @@
 {
   "objectType" : "person",
-  "id": "did:web:example.com:martin",
-  "url": "https://bsky.app/profile/yoozer@example.com",
+  "id": "did:web:example.com",
+  "url": "https://bsky.app/profile/example.com",
   "image": [{
     "url": "http://example.com/martin/image"
   }],

--- a/granary/tests/testdata/actor.bsky.json
+++ b/granary/tests/testdata/actor.bsky.json
@@ -2,7 +2,7 @@
   "$type": "app.bsky.actor.defs#profileView",
   "displayName": "Martin Smith",
   "description": "this is my bio",
-  "handle": "yoozer@example.com",
+  "handle": "example.com",
   "avatar": "http://example.com/martin/image",
-  "did": "did:web:example.com:martin"
+  "did": "did:web:example.com"
 }

--- a/granary/tests/testdata/actor_with_featured.as-from-bsky.json
+++ b/granary/tests/testdata/actor_with_featured.as-from-bsky.json
@@ -1,7 +1,7 @@
 {
   "objectType" : "person",
-  "id": "did:web:example.com:martin",
-  "url": "https://bsky.app/profile/yoozer@example.com",
+  "id": "did:web:example.com",
+  "url": "https://bsky.app/profile/example.com",
   "displayName": "Martin Smith",
   "image": [{
     "url": "http://example.com/avatar"

--- a/granary/tests/testdata/actor_with_featured.bsky.json
+++ b/granary/tests/testdata/actor_with_featured.bsky.json
@@ -1,8 +1,8 @@
 {
   "$type": "app.bsky.actor.defs#profileView",
   "displayName": "Martin Smith",
-  "handle": "yoozer@example.com",
+  "handle": "example.com",
   "avatar": "http://example.com/avatar",
   "banner": "http://example.com/header",
-  "did": "did:web:example.com:martin"
+  "did": "did:web:example.com"
 }

--- a/granary/tests/testdata/note.bsky-from-as.json
+++ b/granary/tests/testdata/note.bsky-from-as.json
@@ -6,9 +6,9 @@
     "cid": "TODO",
     "author": {
       "$type": "app.bsky.actor.defs#profileViewBasic",
-      "did": "",
+      "did": "did:web:example.com",
       "displayName": "Ryan Barrett",
-      "handle": "example.com,2001:ryan",
+      "handle": "example.com",
       "avatar": "http://example.com/ryan/image"
     },
     "record": {

--- a/granary/tests/testdata/repost.as-from-bsky.json
+++ b/granary/tests/testdata/repost.as-from-bsky.json
@@ -6,7 +6,7 @@
     "url": "https://bsky.app/profile/example.com/post/3juzc2tw2dm2h",
     "author": {
       "objectType": "person",
-      "id": "did:web:example.com:bob",
+      "id": "did:web:example.com",
       "url": "https://bsky.app/profile/example.com",
       "displayName": "Bob"
     },
@@ -15,7 +15,7 @@
   },
   "actor": {
     "objectType": "person",
-    "id": "did:web:example.com:alice",
+    "id": "did:web:alice.example.com",
     "url": "https://bsky.app/profile/alice.example.com",
     "displayName": "Alice"
   }

--- a/granary/tests/testdata/repost.bsky-from-as.json
+++ b/granary/tests/testdata/repost.bsky-from-as.json
@@ -6,8 +6,8 @@
     "cid": "TODO",
     "author": {
       "$type": "app.bsky.actor.defs#profileViewBasic",
-      "did": "did:web:example.com:bob",
-      "handle": "example.com/bob",
+      "did": "did:web:example.com",
+      "handle": "example.com",
       "displayName": "Bob"
     },
     "record": {
@@ -25,8 +25,8 @@
     "$type": "app.bsky.feed.defs#reasonRepost",
     "by": {
       "$type": "app.bsky.actor.defs#profileView",
-      "did": "did:web:example.com:alice",
-      "handle": "example.com/alice",
+      "did": "did:web:example.com",
+      "handle": "example.com",
       "displayName": "Alice"
     },
     "indexedAt": "2022-01-02T03:04:05+00:00"

--- a/granary/tests/testdata/repost.bsky.json
+++ b/granary/tests/testdata/repost.bsky.json
@@ -6,7 +6,7 @@
     "cid": "TODO",
     "author": {
       "$type": "app.bsky.actor.defs#profileViewBasic",
-      "did": "did:web:example.com:bob",
+      "did": "did:web:example.com",
       "handle": "example.com",
       "displayName": "Bob"
     },
@@ -25,7 +25,7 @@
     "$type": "app.bsky.feed.defs#reasonRepost",
     "by": {
       "$type": "app.bsky.actor.defs#profileView",
-      "did": "did:web:example.com:alice",
+      "did": "did:web:alice.example.com",
       "handle": "alice.example.com",
       "displayName": "Alice"
     },


### PR DESCRIPTION
As discussed - this simplifies the handling of (web) DIDs and handles somewhat to only support hostname-based handles and DIDs. It also attempts to parse the handle from the tag URI if all else fails. Tests are passing but I might have missed something!