### PR TITLE
Replace upvote/downvote with likes in Bluesky

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -445,10 +445,9 @@ def from_as1(obj, out_type=None, blobs=None):
             **embed,
             '$type': f'app.bsky.embed.record#viewRecord',
             # override these so that trim_nulls below will remove them
-            'downvoteCount': None,
+            'likeCount': None,
             'replyCount': None,
             'repostCount': None,
-            'upvoteCount': None,
           },
         }
         record_record_embed = {
@@ -537,8 +536,7 @@ def from_as1(obj, out_type=None, blobs=None):
       'embed': embed,
       'replyCount': 0,
       'repostCount': 0,
-      'upvoteCount': 0,
-      'downvoteCount': 0,
+      'likeCount': 0,
       'indexedAt': util.now().isoformat(),
     }, ignore=('author', 'createdAt', 'cid', 'description', 'indexedAt',
                'record', 'text', 'title', 'uri'))

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -90,8 +90,7 @@ POST_VIEW_BSKY = {
   },
   'replyCount': 0,
   'repostCount': 0,
-  'upvoteCount': 0,
-  'downvoteCount': 0,
+  'likeCount': 0,
   'indexedAt': '2022-01-02T03:04:05+00:00',
 }
 

--- a/granary/tests/testdata/comment_inreplyto_id.bsky.json
+++ b/granary/tests/testdata/comment_inreplyto_id.bsky.json
@@ -24,8 +24,7 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0,
+    "likeCount": 0,
     "indexedAt": "2022-01-02T03:04:05+00:00"
   }
 }

--- a/granary/tests/testdata/note.bsky.json
+++ b/granary/tests/testdata/note.bsky.json
@@ -36,8 +36,7 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0,
+    "likeCount": 0,
     "indexedAt": "2022-01-02T03:04:05+00:00"
   }
 }

--- a/granary/tests/testdata/quote.bsky.json
+++ b/granary/tests/testdata/quote.bsky.json
@@ -45,9 +45,8 @@
         }
       }
     },
-    "downvoteCount": 0,
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0
+    "likeCount": 0
   }
 }

--- a/granary/tests/testdata/quote_and_attachment.bsky.json
+++ b/granary/tests/testdata/quote_and_attachment.bsky.json
@@ -57,7 +57,6 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0
+    "likeCount": 0
   }
 }

--- a/granary/tests/testdata/quote_and_image.bsky.json
+++ b/granary/tests/testdata/quote_and_image.bsky.json
@@ -56,7 +56,6 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0
+    "likeCount": 0
   }
 }

--- a/granary/tests/testdata/quote_with_image.bsky.json
+++ b/granary/tests/testdata/quote_with_image.bsky.json
@@ -50,7 +50,6 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0
+    "likeCount": 0
   }
 }

--- a/granary/tests/testdata/repost.bsky.json
+++ b/granary/tests/testdata/repost.bsky.json
@@ -17,8 +17,7 @@
     },
     "replyCount": 0,
     "repostCount": 0,
-    "upvoteCount": 0,
-    "downvoteCount": 0,
+    "likeCount": 0,
     "indexedAt": "2022-01-02T03:04:05+00:00"
   },
   "reason": {


### PR DESCRIPTION
Bluesky doesn't actually use up/down votes (anymore?), it uses likes. This mostly just affects test data.