### PR TITLE
Add optional did replacement parameter to web_url_to_at_uri

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -178,8 +178,13 @@ def web_url_to_at_uri(url, handle=None, did=None):
   * ``https://bsky.app/profile/vito.fyi/post/3jt7sst7vok2u``
   * ``https://bsky.app/profile/bsky.app/feed/mutuals``
 
+  If both ``handle`` and ``did`` are provided, and ``handle`` matches the URL,
+  the handle in the resulting URI will be replaced with ``did``.
+
   Args:
     url (str): ``bsky.app`` URL
+    handle (str): Bluesky handle, or None
+    did (str): Valid DID, or None
 
   Returns:
     str: ``at://`` URI, or None

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -201,8 +201,9 @@ def web_url_to_at_uri(url, handle=None, did=None):
   type = match.group('type')
   tid = match.group('tid')
 
-  # If a did has been provided explicitly, replace the existing handle with it.
-  if did and HANDLE_PATTERN.match(id):
+  # If a did and handle have been provided explicitly,
+  # replace the existing handle with the did.
+  if did and handle and id == handle:
     id = did
 
   if type:

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -167,7 +167,7 @@ def at_uri_to_web_url(uri, handle=None):
   return f'{Bluesky.user_url(handle or did)}/{type}/{tid}'
 
 
-def web_url_to_at_uri(url, handle=None):
+def web_url_to_at_uri(url, handle=None, did=None):
   """Converts a ``https://bsky.app`` URL to an ``at://`` URI.
 
   https://atproto.com/specs/at-uri-scheme
@@ -200,6 +200,10 @@ def web_url_to_at_uri(url, handle=None):
   assert id
   type = match.group('type')
   tid = match.group('tid')
+
+  # If a did has been provided explicitly, replace the existing handle with it.
+  if did and HANDLE_PATTERN.match(id):
+    id = did
 
   if type:
     assert tid

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -447,6 +447,11 @@ class BlueskyTest(testutil.TestCase):
     ):
       self.assertEqual(expected, web_url_to_at_uri(url))
 
+      self.assertEqual(
+        'at://did:plc:foo',
+        web_url_to_at_uri('https://bsky.app/profile/foo.com', did='did:plc:foo')
+      )
+
     for url in ('at://foo', 'http://not/bsky.app', 'https://bsky.app/x'):
       with self.assertRaises(ValueError):
         web_url_to_at_uri(url)

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -449,7 +449,22 @@ class BlueskyTest(testutil.TestCase):
 
       self.assertEqual(
         'at://did:plc:foo',
+        web_url_to_at_uri('https://bsky.app/profile/foo.com', handle='foo.com', did='did:plc:foo')
+      )
+
+      self.assertEqual(
+        'at://foo.com',
         web_url_to_at_uri('https://bsky.app/profile/foo.com', did='did:plc:foo')
+      )
+
+      self.assertEqual(
+        'at://foo.com',
+        web_url_to_at_uri('https://bsky.app/profile/foo.com', handle='foo.com')
+      )
+
+      self.assertEqual(
+        'at://foo.com',
+        web_url_to_at_uri('https://bsky.app/profile/foo.com', handle='alice.com', did='did:plc:foo')
       )
 
     for url in ('at://foo', 'http://not/bsky.app', 'https://bsky.app/x'):


### PR DESCRIPTION
This is the first bit needed to address https://github.com/snarfed/bridgy/issues/1575;  I wasn't sure if it was better to use the regex or simply match on provided handle parameter (currently unused)?