### PR TITLE
Add image aspect ratio for Bluesky

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,6 +70,7 @@ multiformats==0.3.1.post4
 multiformats-config==0.3.1
 oauthlib==3.2.2
 packaging==24.2
+Pillow==11.0.0
 pkce==1.0.3
 praw==7.8.1
 prawcore==2.4.0


### PR DESCRIPTION
Hey @snarfed, here's my attempt at adding the image aspect ratio. Please tear it apart with extreme prejudice, I haven't written Python for many months now.

I added Pillow as a dependency to Granary - do we need to add it to Bridgy too? It wouldn't work locally unless I installed it there but I probably am misunderstanding how the local installation stuff in Pip works.

Fixes #843 