### PR TITLE
rss.from_as1: remove possible addition of invalid author element

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ Standardize function and method names in all modules to `to_as1`, `from_as`, etc
   * `object_to_json`: Improve handling of items with multiple types by removing `inReplyTo` from likes, shares, etc ([snarfed/bridgy-fed#941](https://github.com/snarfed/bridgy-fed/issues/941)).
 * `rss`:
   * Support image enclosures, both directions.
+  * `from_as1`:
+    * Bug fix: remove use of default `author` value `'-'` since RSS spec requires author values to include valid email addresses.
 * `source`:
   * `Source.postprocess_object`: add new `first_link_to_attachment` boolean kwarg to fetch and generate a preview `attachment` for the first link in the HTML `content`, if any.
 

--- a/granary/rss.py
+++ b/granary/rss.py
@@ -125,7 +125,7 @@ def from_as1(activities, actor=None, title=None, feed_url=None,
                or as1_author.get('url') or as1_author.get('id')),
       'uri': as1_author.get('url') or as1_author.get('id'),
     }
-    if 'email' in as1_author:
+    if as1_author.get('email'):
       rss_author['email'] = as1_author['email']
     item.author(rss_author)
 

--- a/granary/rss.py
+++ b/granary/rss.py
@@ -119,14 +119,15 @@ def from_as1(activities, actor=None, title=None, feed_url=None,
       t.get('objectType') not in ('article', 'person', 'mention')]
     item.category(categories)
 
-    author = as1.get_object(obj, 'author')
-    author = {
-      'name': (author.get('displayName') or author.get('username')
-               or author.get('url') or author.get('id')),
-      'uri': author.get('url') or author.get('id'),
-      'email': author.get('email') or '-',
+    as1_author = as1.get_object(obj, 'author')
+    rss_author = {
+      'name': (as1_author.get('displayName') or as1_author.get('username')
+               or as1_author.get('url') or as1_author.get('id')),
+      'uri': as1_author.get('url') or as1_author.get('id'),
     }
-    item.author(author)
+    if 'email' in as1_author:
+      rss_author['email'] = as1_author['email']
+    item.author(rss_author)
 
     published = obj.get('published') or obj.get('updated')
     if published and isinstance(published, str):
@@ -176,7 +177,7 @@ def from_as1(activities, actor=None, title=None, feed_url=None,
       fg.podcast.itunes_summary(summary)
     fg.podcast.itunes_explicit('no')
     fg.podcast.itunes_block(False)
-    name = author.get('name')
+    name = rss_author.get('name')
     if name:
       fg.podcast.itunes_author(name)
     if image:

--- a/granary/tests/test_rss.py
+++ b/granary/tests/test_rss.py
@@ -211,10 +211,10 @@ The original post]]></description>
   def test_author_string_id(self):
     got = rss.from_as1([{
         'content': 'foo bar',
-        'author': 'tag:bob',
+        'author': 'tag:bob',  # should be ignored for RSS
         'email': 'bob@example.com',
       }], feed_url='http://this')
-    self.assert_multiline_in('<author>bob@example.com (tag:bob)</author>', got)
+    self.assertNotRegex(got, r'<author>.*</author>')
 
   def test_order(self):
     got = rss.from_as1([

--- a/granary/tests/test_rss.py
+++ b/granary/tests/test_rss.py
@@ -212,7 +212,6 @@ The original post]]></description>
     got = rss.from_as1([{
         'content': 'foo bar',
         'author': 'tag:bob',  # should be ignored for RSS
-        'email': 'bob@example.com',
       }], feed_url='http://this')
     self.assertNotRegex(got, r'<author>.*</author>')
 

--- a/granary/tests/test_rss.py
+++ b/granary/tests/test_rss.py
@@ -101,14 +101,13 @@ The original post]]></description>
     self.assert_multiline_in("""
 <item>
 <description><![CDATA[foo bar]]></description>
-<author>- (Alice)</author>
+<author>alice@example.com (Alice)</author>
 </item>
 
 <item>
 <title>a thing I wrote</title>
 <link>http://read/this</link>
 <description><![CDATA[its gud]]></description>
-<author>-</author>
 <guid isPermaLink="true">http://read/this</guid>
 </item>
 """, rss.from_as1([{
@@ -119,6 +118,7 @@ The original post]]></description>
         'displayName': 'Alice',
         'url': 'http://it/me',
         'image': 'http://my/pic.jpg',
+        'email': 'alice@example.com',
       },
     },
   }, {
@@ -203,16 +203,18 @@ The original post]]></description>
         'author': {
           'objectType':'person',
           'displayName':'Mrs. Baz',
+          'email': 'baz@example.com',
         },
       }], feed_url='http://this')
-    self.assert_multiline_in('<author>- (Mrs. Baz)</author>', got)
+    self.assert_multiline_in('<author>baz@example.com (Mrs. Baz)</author>', got)
 
   def test_author_string_id(self):
     got = rss.from_as1([{
         'content': 'foo bar',
         'author': 'tag:bob',
+        'email': 'bob@example.com',
       }], feed_url='http://this')
-    self.assert_multiline_in('<author>- (tag:bob)</author>', got)
+    self.assert_multiline_in('<author>bob@example.com (tag:bob)</author>', got)
 
   def test_order(self):
     got = rss.from_as1([

--- a/granary/tests/testdata/feed_with_audio_video.as-from-rss.json
+++ b/granary/tests/testdata/feed_with_audio_video.as-from-rss.json
@@ -21,7 +21,14 @@
     "duration": 328,
     "size": 7770000
   }],
-  "author": {"displayName": "-"}
+  "author": {
+    "displayName": "Stuff",
+    "image": [{
+      "url": "http://example.com/martin/image"
+    }],
+    "summary": "some stuff by meee",
+    "url": "http://site/"
+  }
 },
 {
   "id": "http://vidjo/post",
@@ -43,5 +50,12 @@
     "duration": 428,
     "size": 8880000
   }],
-  "author": {"displayName": "-"}
+  "author": {
+    "displayName": "Stuff",
+    "image": [{
+      "url": "http://example.com/martin/image"
+    }],
+    "summary": "some stuff by meee",
+    "url": "http://site/"
+  }
 }]

--- a/granary/tests/testdata/feed_with_audio_video.rss.xml
+++ b/granary/tests/testdata/feed_with_audio_video.rss.xml
@@ -24,7 +24,6 @@
     <description><![CDATA[<p>some HTML</p>
     <p><audio class="u-audio" src="http://a/podcast.mp3" controls="controls">Your browser does not support the audio tag. <a href="http://a/podcast.mp3">Click here to listen directly.</a></audio>
     </p>]]></description>
-    <author>-</author>
     <guid isPermaLink="true">http://podcast/post</guid>
     <category>a tag</category>
     <enclosure url="http://a/podcast.mp3" length="7770000" type="audio/mpeg"/>
@@ -38,7 +37,6 @@
     <description><![CDATA[
     <p><video class="u-video" src="http://a/vidjo.mov" controls="controls" poster="">Your browser does not support the video tag. <a href="http://a/vidjo.mov">Click here to view directly. </a></video>
     </p>]]></description>
-    <author>-</author>
     <guid isPermaLink="true">http://vidjo/post</guid>
     <enclosure url="http://a/vidjo.mov" length="8880000" type="video/quicktime"/>
     <pubDate>Tue, 04 Dec 2012 00:00:00 +0000</pubDate>

--- a/granary/tests/testdata/feed_with_note.as-from-rss.json
+++ b/granary/tests/testdata/feed_with_note.as-from-rss.json
@@ -4,5 +4,12 @@
   "objectType": "note",
   "content": "something i have to say. and just long enough that it has to be ellipsized.\n<p>\n<a class=\"link\" href=\"http://a/note\">\n<img alt=\"\" class=\"u-photo\" src=\"http://pic/1\" />\n</a>\n</p>\n<p>\n<a class=\"link\" href=\"http://a/note\">\n<img alt=\"\" class=\"u-photo\" src=\"http://pic/2\" />\n</a>\n</p>",
   "published": "2012-12-04T00:00:00+00:00",
-  "author": {"displayName": "-"}
+  "author": {
+    "displayName": "Stuff",
+    "image": [{
+      "url": "http://example.com/martin/image"
+    }],
+    "summary": "some stuff by meee",
+    "url": "http://site/"
+  }
 }]

--- a/granary/tests/testdata/feed_with_note.rss.xml
+++ b/granary/tests/testdata/feed_with_note.rss.xml
@@ -28,7 +28,6 @@
 <img class="u-photo" src="http://pic/2" alt="" />
 </a>
 </p>]]></description>
-    <author>-</author>
     <guid isPermaLink="true">http://a/note</guid>
     <enclosure url="http://pic/1" length="0" type=""/>
     <pubDate>Tue, 04 Dec 2012 00:00:00 +0000</pubDate>


### PR DESCRIPTION
I appreciate this project, thanks for your work on it!

Here's a change that I think will fix a few broken cases such as [this one](https://github.com/capjamesg/hugging-face-papers-rss/issues/3) that directly publish RSS converted from JSON feeds via granary.io.

In brief, we adhere closer to the RSS spec by removing the use of the default author email value `'-'` when constructing an RSS item.

(relevant upstream project code: https://github.com/lkiesow/python-feedgen/blob/v1.0.0/feedgen/entry.py#L366-L372)

### illustrative example

https://granary.io/url?input=jsonfeed&output=rss&url=https://jamesg.blog/hf-papers.json

The above link produces an RSS file that at the time of writing is technically invalid when [checked](https://validator.w3.org/feed/#validate_by_input). This invalidity appears to break some RSS readers.

<details>
<summary>url.rss excerpt</summary>

```
<?xml version='1.0' encoding='UTF-8'?>
<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" version="2.0">
  <channel>
    <title>Feed for https://jamesg.blog/hf-papers.json</title>
    <link>https://jamesg.blog/</link>
    <description>-</description>
    <atom:link href="https://granary.io/url?input=jsonfeed&amp;output=rss&amp;url=https://jamesg.blog/hf-papers.json" rel="self"/>
    <docs>http://www.rssboard.org/rss-specification</docs>
    <generator>granary</generator>
    <language>en</language>
    <lastBuildDate>Wed, 18 Dec 2024 05:46:10 +0000</lastBuildDate>
    <item>
      <title>Are Your LLMs Capable of Stable Reasoning?</title>
      <link>https://huggingface.co/papers/2412.13147</link>
      <description><![CDATA[The rapid advancement of Large Language Models (LLMs) has demonstrated remarkable progress in complex reasoning tasks. However, a significant discrepancy persists between benchmark performances and real-world applications. We identify this gap as primarily stemming from current evaluation protocols and metrics, which inadequately capture the full spectrum of LLM capabilities, particularly in complex reasoning tasks where both accuracy and consistency are crucial. This work makes two key contributions. First, we introduce G-Pass@k, a novel evaluation metric that provides a continuous assessment of model performance across multiple sampling attempts, quantifying both the model's peak performance potential and its stability. Second, we present LiveMathBench, a dynamic benchmark comprising challenging, contemporary mathematical problems designed to minimize data leakage risks during evaluation. Through extensive experiments using G-Pass@k on state-of-the-art LLMs with LiveMathBench, we provide comprehensive insights into both their maximum capabilities and operational consistency. Our findings reveal substantial room for improvement in LLMs' "realistic" reasoning capabilities, highlighting the need for more robust evaluation methods. The benchmark and detailed results are available at: https://github.com/open-compass/GPassK.]]></description>


      <author>-</author> <!-- INVALID -->


      <guid isPermaLink="true">https://huggingface.co/papers/2412.13147</guid>
    </item>

<!-- etc... -->
```

</details>