### PR TITLE
bluesky.from_as1: preserve mentions of unresolved handles as links

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -879,11 +879,16 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
             did = client.com.atproto.identity.resolveHandle(handle=did)['did']
 
         if not did:
-          continue
-        facet['features'] = [{
-          '$type': 'app.bsky.richtext.facet#mention',
-          'did': did,
-        }]
+          # preserve the profile link if we couldn't resolve it
+          facet['features'] = [{
+            '$type': 'app.bsky.richtext.facet#link',
+            'uri': tag_url,
+          }]
+        else:
+          facet['features'] = [{
+            '$type': 'app.bsky.richtext.facet#mention',
+            'did': did,
+          }]
 
       else:
         facet['features'] = [{

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1476,6 +1476,34 @@ class BlueskyTest(testutil.TestCase):
       }],
     }))
 
+  def test_from_as1_link_mention_unresolved(self):
+    content = 'foo <a href="https://instance.name/@you">@you</a> baz'
+
+    self.assert_equals({
+      '$type': 'app.bsky.feed.post',
+      'createdAt': '2022-01-02T03:04:05.000Z',
+      'text': 'foo @you baz',
+      'fooOriginalText': content,
+      'facets': [{
+        '$type': 'app.bsky.richtext.facet',
+        'features': [{
+          '$type': 'app.bsky.richtext.facet#link',
+          'uri': 'https://instance.name/@you',
+        }],
+        'index': {
+          'byteStart': 4,
+          'byteEnd': 8,
+        },
+      }],
+    }, self.from_as1({
+      'objectType': 'note',
+      'content': content,
+      'tags': [{
+        'objectType': 'mention',
+        'displayName': '@you',
+      }],
+    }))
+
   def test_from_as1_hashtag_special_chars(self):
     self.assert_equals({
       '$type': 'app.bsky.feed.post',

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1230,7 +1230,7 @@ class BlueskyTest(testutil.TestCase):
     }))
 
   def test_from_as1_tag_mention_html_content_guess_index(self):
-    content = '<p>foo <a href="https://bsky.app/...">@you.com</a> bar</p>'
+    content = '<p>foo <a href="https://bsky.app/profile/did:plc:foo">@you.com</a> bar</p>'
     self.assert_equals({
       **POST_BSKY_FACET_MENTION,
       'fooOriginalText': content,
@@ -1245,7 +1245,7 @@ class BlueskyTest(testutil.TestCase):
     }))
 
   def test_from_as1_tag_mention_display_name_server_html_content_guess_index(self):
-    content = '<p>foo <a href="https://bsky.app/...">@you.com</a> bar</p>'
+    content = '<p>foo <a href="https://bsky.app/profile/did:plc:foo">@you.com</a> bar</p>'
     self.assert_equals({
       **POST_BSKY_FACET_MENTION,
       'fooOriginalText': content,
@@ -1273,7 +1273,7 @@ class BlueskyTest(testutil.TestCase):
     }, self.from_as1(note))
 
   def test_from_as1_tag_mention_at_beginning(self):
-    content = '<p><span class="h-card" translate="no"><a href="https://bsky.brid.gy/r/https://bsky.app/profile/shreyanjain.net" class="u-url mention">@<span>shreyanjain.net</span></a></span> hello there</p>'
+    content = '<p><span class="h-card" translate="no"><a href="https://bsky.app/profile/did:plc:foo" class="u-url mention">@<span>shreyanjain.net</span></a></span> hello there</p>'
 
     self.assert_equals({
       '$type': 'app.bsky.feed.post',


### PR DESCRIPTION
An attempt at fixing https://github.com/snarfed/bridgy-fed/issues/1163