### PR TITLE
bluesky.from_as1: set aspectRatio for videos too

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -448,7 +448,7 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
       provided, or if this doesn't have an ``image`` or similar URL in the input
       object, its output blob will be omitted.
     aspects (dict): optional mapping from str URL to int (width,height) tuple.
-        Used to provide aspect ratio in image embeds.
+        Used to provide aspect ratio in image/video embeds.
     client (Bluesky or lexrpc.Client): optional; if provided, this will be used
       to make API calls to PDSes to fetch and populate CIDs for records
       referenced by replies, likes, reposts, etc.
@@ -692,6 +692,12 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
           'video': blob,
           'alt': alt,
         }
+
+        if aspect := aspects.get(url):
+          video_record_embed['aspectRatio'] = {
+            'width': aspect[0],
+            'height': aspect[1]
+          }
         break
 
     # by default, original post link goes into an external embed. Bluesky can't

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1541,6 +1541,13 @@ class BlueskyTest(testutil.TestCase):
     }}
     self.assert_equals(expected, self.from_as1(POST_AS_VIDEO, blobs=blobs))
 
+  def test_from_as1_post_with_video_blobs_aspect(self):
+    expected = copy.deepcopy(POST_BSKY_VIDEO)
+    expected['embed']['aspectRatio'] = {'width': 123, 'height': 456}
+    blobs = {NEW_BLOB_URL: {**NEW_BLOB, 'mimeType': 'video/mp4'}}
+    aspects = {NEW_BLOB_URL: (123, 456)}
+    self.assert_equals(expected, self.from_as1(POST_AS_VIDEO, blobs=blobs, aspects=aspects))
+
   def test_from_as1_post_view_with_image(self):
     expected = copy.deepcopy(POST_VIEW_BSKY_IMAGES)
     del expected['record']['embed']


### PR DESCRIPTION
Extend #844 to videos. Haven't added anything to calculate these as `create` doesn't seem to support uploading videos.