### PR TITLE
Bluesky.from_as1: extract any non-linked @-mention of a valid handle

### DIFF
--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -960,7 +960,26 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
     if client:
       for match in AT_MENTION_PATTERN.finditer(text):
         handle = match.group(0).strip()
+
+        index = {
+          'byteStart': len(text[:match.start(1)].encode()),
+          'byteEnd': len(text[:match.end(1)].encode()),
+        }
+
+        # check if no overlap with any existing facets
+        def index_range_overlap(index1, index2):
+          start1 = index1.get('byteStart', 0)
+          end1 = index1.get('byteEnd', 0)
+          start2 = index2.get('byteStart', 0)
+          end2 = index2.get('byteEnd', 0)
+          return (start1 >= start2 and start1 < end2) or (end1 > start2 and end1 < end2)
+
+        if any('index' in f and index_range_overlap(index, f['index']) for f in facets):
+          continue
+
+        # attempt to resolve handle
         did = client.com.atproto.identity.resolveHandle(handle=handle[1:])['did']
+
         if did:
           facet = {
             '$type': 'app.bsky.richtext.facet',
@@ -968,22 +987,10 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
               '$type': 'app.bsky.richtext.facet#mention',
               'did': did,
             }],
-            'index': {
-              'byteStart': len(text[:match.start(1)].encode()),
-              'byteEnd': len(text[:match.end(1)].encode()),
-            }
+            'index': index
           }
 
-          # add if no overlap with any existing facets
-          def index_range_overlap(index1, index2):
-            start1 = index1.get('byteStart', 0)
-            end1 = index1.get('byteEnd', 0)
-            start2 = index2.get('byteStart', 0)
-            end2 = index2.get('byteEnd', 0)
-            return (start1 >= start2 and start1 < end2) or (end1 > start2 and end1 < end2)
-
-          if not any('index' in f and index_range_overlap(facet['index'], f['index']) for f in facets):
-            facets.append(facet)
+          facets.append(facet)
 
     # if we truncated this post's text, override external embed with link to
     # original post. (if there are images, we added a link in the text instead,

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -496,18 +496,6 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
   obj = copy.deepcopy(obj)
   Source.postprocess_object(obj, mentions=True)
 
-  # extract un-linked @-mentions
-  if client and 'content' in obj:
-    for handle in AT_MENTION_PATTERN.finditer(obj['content']):
-      handle = handle.group(0).strip()
-      did = client.com.atproto.identity.resolveHandle(handle=handle[1:])['did']
-      if did:
-        obj['tags'].append({
-          'objectType': 'mention',
-          'url': did,
-          'displayName': handle,
-        })
-
   ret = None
 
   # for nested from_as1 calls, if necessary
@@ -771,6 +759,18 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
           content = content[:start] + link['text'] + content[end:]
 
     tags = util.get_list(obj, 'tags')
+
+    # extract un-linked @-mentions
+    if client:
+      for handle in AT_MENTION_PATTERN.finditer(content):
+        handle = handle.group(0).strip()
+        did = client.com.atproto.identity.resolveHandle(handle=handle[1:])['did']
+        if did:
+          tags.append({
+            'objectType': 'mention',
+            'url': did,
+            'displayName': handle,
+          })
 
     # handle summary. for articles, use instead of content. for notes, assume
     # it's a fediverse-style content warnings, add above content.

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -748,7 +748,7 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
           start, end = link.span()
           # our regexp isn't perfect, so skip links that we can't extract a
           # clean URL from
-          if util.is_web(link['url']) and not link['text'].startswith(('@', '#')):
+          if util.is_web(link['url']) and not link['text'].strip().startswith(('@', '#')):
             link_tags.append({
               'objectType': 'link',
               'displayName': link['text'],

--- a/granary/bluesky.py
+++ b/granary/bluesky.py
@@ -47,7 +47,7 @@ HANDLE_REGEX = (
 )
 HANDLE_PATTERN = re.compile(r'^' + HANDLE_REGEX + r'$')
 DID_WEB_PATTERN = re.compile(r'^did:web:' + HANDLE_REGEX + r'$')
-AT_MENTION_PATTERN = re.compile(r'(?:^|\s)@' + HANDLE_REGEX + r'(?:$|\s)')
+AT_MENTION_PATTERN = re.compile(r'(?:^|\s)(@' + HANDLE_REGEX + r')(?:$|\s)')
 
 MAX_MEDIA_SIZE_BYTES = 5_000_000
 
@@ -760,18 +760,6 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
 
     tags = util.get_list(obj, 'tags')
 
-    # extract un-linked @-mentions
-    if client:
-      for handle in AT_MENTION_PATTERN.finditer(content):
-        handle = handle.group(0).strip()
-        did = client.com.atproto.identity.resolveHandle(handle=handle[1:])['did']
-        if did:
-          tags.append({
-            'objectType': 'mention',
-            'url': did,
-            'displayName': handle,
-          })
-
     # handle summary. for articles, use instead of content. for notes, assume
     # it's a fediverse-style content warnings, add above content.
     # https://github.com/snarfed/bridgy-fed/issues/1001
@@ -967,6 +955,35 @@ def from_as1(obj, out_type=None, blobs=None, aspects=None, client=None,
 
       if facet not in facets:
         facets.append(facet)
+
+    # extract un-linked @-mentions
+    if client:
+      for match in AT_MENTION_PATTERN.finditer(text):
+        handle = match.group(0).strip()
+        did = client.com.atproto.identity.resolveHandle(handle=handle[1:])['did']
+        if did:
+          facet = {
+            '$type': 'app.bsky.richtext.facet',
+            'features': [{
+              '$type': 'app.bsky.richtext.facet#mention',
+              'did': did,
+            }],
+            'index': {
+              'byteStart': len(text[:match.start(1)].encode()),
+              'byteEnd': len(text[:match.end(1)].encode()),
+            }
+          }
+
+          # add if no overlap with any existing facets
+          def index_range_overlap(index1, index2):
+            start1 = index1.get('byteStart', 0)
+            end1 = index1.get('byteEnd', 0)
+            start2 = index2.get('byteStart', 0)
+            end2 = index2.get('byteEnd', 0)
+            return (start1 >= start2 and start1 < end2) or (end1 > start2 and end1 < end2)
+
+          if not any('index' in f and index_range_overlap(facet['index'], f['index']) for f in facets):
+            facets.append(facet)
 
     # if we truncated this post's text, override external embed with link to
     # original post. (if there are images, we added a link in the text instead,

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1128,6 +1128,19 @@ class BlueskyTest(testutil.TestCase):
       'content': content,
     }, client=self.bs), ignore=['createdAt'])
 
+  # resolveHandle
+  @patch('requests.get', return_value=requests_response({'did': 'did:plc:foo'}))
+  def test_from_as1_bare_mention(self, _):
+    content = 'foo @you.com bar'
+    self.assert_equals({
+      **POST_BSKY_FACET_MENTION,
+      'fooOriginalText': content,
+      'fooOriginalUrl': 'https://bsky.app/profile/did:al:ice/post/tid',
+    }, self.from_as1({
+      **POST_AS['object'],
+      'content': content,
+    }, client=self.bs), ignore=['createdAt'])
+
   def test_from_as1_tag_hashtag(self):
     self.assert_equals(POST_BSKY_FACET_HASHTAG, self.from_as1(NOTE_AS_TAG_HASHTAG))
 

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1141,6 +1141,33 @@ class BlueskyTest(testutil.TestCase):
       'content': content,
     }, client=self.bs), ignore=['createdAt'])
 
+  # resolveHandle
+  @patch('requests.get', return_value=requests_response({'did': 'did:plc:foo'}))
+  def test_from_as1_bare_mention_in_link(self, _):
+    content = 'foo <a href="https://a.link/...">@you.com bar</a>'
+    expected = {
+      '$type': 'app.bsky.feed.post',
+      'text': 'foo @you.com bar',
+      'fooOriginalText': content,
+      'fooOriginalUrl': 'https://bsky.app/profile/did:al:ice/post/tid',
+      'createdAt': '2022-01-02T03:04:05.000Z',
+      'facets': [{
+        '$type': 'app.bsky.richtext.facet',
+        'features': [{
+          '$type': 'app.bsky.richtext.facet#link',
+          'uri': 'https://a.link/...',
+        }],
+        'index': {
+          'byteStart': 4,
+          'byteEnd': 16,
+        },
+      }],
+    }
+    self.assert_equals(expected, self.from_as1({
+      **POST_AS['object'],
+      'content': content,
+    }, client=self.bs), ignore=['createdAt'])
+
   def test_from_as1_tag_hashtag(self):
     self.assert_equals(POST_BSKY_FACET_HASHTAG, self.from_as1(NOTE_AS_TAG_HASHTAG))
 

--- a/granary/tests/test_bluesky.py
+++ b/granary/tests/test_bluesky.py
@@ -1130,6 +1130,19 @@ class BlueskyTest(testutil.TestCase):
 
   # resolveHandle
   @patch('requests.get', return_value=requests_response({'did': 'did:plc:foo'}))
+  def test_from_as1_tag_mention_url_html_link_space(self, _):
+    content = 'foo<a href="https://bsky.app/profile/you.com"> @you.com</a> bar'
+    self.assert_equals({
+      **POST_BSKY_FACET_MENTION,
+      'fooOriginalText': content,
+      'fooOriginalUrl': 'https://bsky.app/profile/did:al:ice/post/tid',
+    }, self.from_as1({
+      **POST_AS['object'],
+      'content': content,
+    }, client=self.bs), ignore=['createdAt'])
+
+  # resolveHandle
+  @patch('requests.get', return_value=requests_response({'did': 'did:plc:foo'}))
   def test_from_as1_bare_mention(self, _):
     content = 'foo @you.com bar'
     self.assert_equals({


### PR DESCRIPTION
This is quite possibly a Bad Idea, but I've typed out the code so might as well open this.

My motivation here is that it's currently almost impossible to get a non-bridged users attention, but also that this is what would happen if you put the exact same text into a post using the bluesky app.

(This doesn't affect any existing tests, but I'm sure it'll have plenty of weird edge cases)